### PR TITLE
Align node feature is added

### DIFF
--- a/src/bindings/python/ctypes/libsbmlnetworkeditor.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetworkeditor.py.cmake
@@ -111,7 +111,26 @@ class LibSBMLNetworkEditor:
             for i in range(len(locked_nodes)):
                 locked_nodes_ptr[i] = ctypes.c_char_p(locked_nodes[i].encode())
 
-        return lib.c_api_autolayout(self.sbml_object, ctypes.c_double(stiffness), ctypes.c_double(gravity), use_magnetism, use_boundary, use_grid, len(locked_nodes), locked_nodes_ptr)
+        return lib.c_api_autolayout(self.sbml_object, ctypes.c_double(stiffness), ctypes.c_double(gravity), use_magnetism, use_boundary, use_grid, locked_nodes_ptr, len(locked_nodes))
+
+    def align(self, nodes, alignment="center"):
+        """
+        Aligns the given nodes in the given alignment type form in the given SBMLDocument
+
+        :Parameters:
+
+            - nodes (list): a list that determines the nodes to be aligned
+            - alignment (string, optional): a string (default: "center") that determines the type of alignment to be applied ("top", "bottom", "left", "right", "center", "middle", "circular")
+
+        :Returns:
+
+            true on success and false if the alignment could not be applied
+        """
+        nodes_ptr = (ctypes.c_char_p * len(nodes))()
+        for i in range(len(nodes)):
+            nodes_ptr[i] = ctypes.c_char_p(nodes[i].encode())
+
+        return lib.c_api_align(self.sbml_object, nodes_ptr, len(nodes), str(alignment).encode())
 
     def getSBMLLevel(self):
         """
@@ -261,7 +280,7 @@ class LibSBMLNetworkEditor:
             for i in range(len(locked_nodes)):
                 locked_nodes_ptr[i] = ctypes.c_char_p(locked_nodes[i].encode())
 
-        return lib.c_api_createDefaultLayout(self.sbml_object, ctypes.c_double(stiffness), ctypes.c_double(gravity), use_magnetism, use_boundary, use_grid, locked_nodes_ptr)
+        return lib.c_api_createDefaultLayout(self.sbml_object, ctypes.c_double(stiffness), ctypes.c_double(gravity), use_magnetism, use_boundary, use_grid, locked_nodes_ptr, len(locked_nodes))
 
     def getCanvasWidth(self, layout_index=0):
         """

--- a/src/c_api/libsbml_ne_c_api.cpp
+++ b/src/c_api/libsbml_ne_c_api.cpp
@@ -34,7 +34,7 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE {
     }
 
     int c_api_autolayout(SBMLDocument *document, const double stiffness, const double gravity, const bool useMagnetism,
-                   const bool useBoundary, const bool useGrid, const int lockedNodesSize, const char **lockedNodeIds) {
+                   const bool useBoundary, const bool useGrid, const char **lockedNodeIds, const int lockedNodesSize) {
         std::vector <std::string> lockedNodeIdsVector = std::vector<std::string>();
         if (lockedNodeIds) {
             for (int i = 0; i < lockedNodesSize; i++)
@@ -42,6 +42,15 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE {
         }
 
         return autolayout(document, stiffness, gravity, useMagnetism, useBoundary, useGrid, lockedNodeIdsVector);
+    }
+
+    int c_api_align(SBMLDocument* document, const char **nodeIds, const int nodesSize,  const char* alignment) {
+        std::vector <std::string> nodeIdsVector = std::vector<std::string>();
+        if (nodeIds) {
+            for (int i = 0; i < nodesSize; i++)
+                nodeIdsVector.emplace_back(nodeIds[i]);
+        }
+        return align(document, nodeIdsVector, alignment);
     }
 
     const int c_api_getNumLayouts(SBMLDocument* document) {
@@ -53,7 +62,7 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE {
     }
 
     int c_api_createDefaultLayout(SBMLDocument* document, const double stiffness, const double gravity, const bool useMagnetism,
-                                  const bool useBoundary, const bool useGrid, const int lockedNodesSize, const char **lockedNodeIds) {
+                                  const bool useBoundary, const bool useGrid, const char **lockedNodeIds, const int lockedNodesSize) {
         std::vector <std::string> lockedNodeIdsVector = std::vector<std::string>();
         if (lockedNodeIds) {
             for (int i = 0; i < lockedNodesSize; i++)

--- a/src/c_api/libsbml_ne_c_api.h
+++ b/src/c_api/libsbml_ne_c_api.h
@@ -55,12 +55,20 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE {
     /// @param useMagnetism a variable that determines whether to use magnetism in the autolayout algorithm.
     /// @param useBoundary a variable that determines whether to use boundary restriction in the autolayout algorithm.
     /// @param useGrid a variable that determines whether to use grid restriction in the autolayout algorithm.
-    /// @param lockedNodesSize the size of lockedNodeIds
     /// @param lockedNodeIds an array of strings containing the ids of the nodes that should be locked in the autolayout algorithm.
+    /// @param lockedNodesSize the size of lockedNodeIds
     /// @return integer value indicating success/failure of the function.
     LIBSBML_NETWORKEDITOR_EXTERN int c_api_autolayout(SBMLDocument* document, const double stiffness = 10.0, const double gravity = 15.0,
                                                 const bool useMagnetism = false, const bool useBoundary = false, const bool useGrid = false,
-                                                const int lockedNodesSize = 0, const char** lockedNodeIds = NULL);
+                                                const char** lockedNodeIds = NULL, const int lockedNodesSize = 0);
+
+    /// @brief Align the nodes position in the SBML document in the given alignment type.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param nodeIds an array of strings containing the ids of the nodes that should be aligned.
+    /// @param nodesSize the size of nodeIds
+    /// @param alignment determines how to align the nodes.
+    /// @return integer value indicating success/failure of the function.
+    LIBSBML_NETWORKEDITOR_EXTERN int c_api_align(SBMLDocument* document, const char **nodeIds, const int nodesSize,  const char* alignment);
 
     /// @brief Returns the number of items in the ListOfLayouts of this SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -85,7 +93,7 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBML_NETWORKEDITOR_EXTERN int c_api_createDefaultLayout(SBMLDocument* document, const double stiffness = 10.0, const double gravity = 15.0,
                                                                const bool useMagnetism = false, const bool useBoundary = false, const bool useGrid = false,
-                                                               const int lockedNodesSize = 0, const char** lockedNodeIds = NULL);
+                                                               const char** lockedNodeIds = NULL, const int lockedNodesSize = 0);
 
     /// @brief Returns the value of the "width" attribute of the Dimensions object of the Layout object
     /// with the given index in the ListOfLayouts of the SBML document.

--- a/src/libsbml_ne_layout_helpers.cpp
+++ b/src/libsbml_ne_layout_helpers.cpp
@@ -459,6 +459,117 @@ std::vector<SpeciesReferenceGlyph*> getAssociatedSpeciesReferenceGlyphsWithReact
     return speciesReferenceGlyphs;
 }
 
+void alignGraphicalObjects(std::vector<GraphicalObject*> graphicalObjects, const std::string& alignment) {
+    if (stringCompare(alignment, "top"))
+        alignGraphicalObjectsToTop(graphicalObjects);
+    else if (stringCompare(alignment, "center"))
+        alignGraphicalObjectsToCenter(graphicalObjects);
+    else if (stringCompare(alignment, "bottom"))
+        alignGraphicalObjectsToBottom(graphicalObjects);
+    else if (stringCompare(alignment, "left"))
+        alignGraphicalObjectsToLeft(graphicalObjects);
+    else if (stringCompare(alignment, "middle"))
+        alignGraphicalObjectsToMiddle(graphicalObjects);
+    else if (stringCompare(alignment, "right"))
+        alignGraphicalObjectsToRight(graphicalObjects);
+    else if (stringCompare(alignment, "circular"))
+        alignGraphicalObjectsCircularly(graphicalObjects);
+    else
+        std::cerr << "error: " + alignment + " is an Invalid alignment type\n";
+}
+
+void alignGraphicalObjectsToTop(std::vector<GraphicalObject*> graphicalObjects) {
+    double minY = getMinPositionY(graphicalObjects);
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setY(minY);
+}
+
+void alignGraphicalObjectsToCenter(std::vector<GraphicalObject*> graphicalObjects) {
+    double centerX = 0.5 * (getMinPositionX(graphicalObjects) + getMaxPositionX(graphicalObjects));
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setX(centerX);
+}
+
+void alignGraphicalObjectsToBottom(std::vector<GraphicalObject*> graphicalObjects) {
+    double maxY = getMaxPositionY(graphicalObjects);
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setY(maxY);
+}
+
+void alignGraphicalObjectsToLeft(std::vector<GraphicalObject*> graphicalObjects) {
+    double minX = getMinPositionX(graphicalObjects);
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setX(minX);
+}
+
+void alignGraphicalObjectsToMiddle(std::vector<GraphicalObject*> graphicalObjects) {
+    double centerY = 0.5 * (getMinPositionY(graphicalObjects) + getMaxPositionY(graphicalObjects));
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setY(centerY);
+}
+
+void alignGraphicalObjectsToRight(std::vector<GraphicalObject*> graphicalObjects) {
+    double maxX = getMaxPositionX(graphicalObjects);
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+        graphicalObjects.at(i)->getBoundingBox()->setX(maxX);
+}
+
+void alignGraphicalObjectsCircularly(std::vector<GraphicalObject*> graphicalObjects) {
+    double centerX = 0.5 * (getMinPositionX(graphicalObjects) + getMaxPositionX(graphicalObjects));
+    double centerY = 0.5 * (getMinPositionY(graphicalObjects) + getMaxPositionY(graphicalObjects));
+    double radius = std::max(0.5 * (getMaxPositionX(graphicalObjects) - getMinPositionX(graphicalObjects)),
+                             0.5 * (getMaxPositionY(graphicalObjects) - getMinPositionY(graphicalObjects)));
+    double angle = 2 * M_PI / graphicalObjects.size();
+    for (unsigned int i = 0; i < graphicalObjects.size(); i++) {
+        graphicalObjects.at(i)->getBoundingBox()->setX(centerX + radius * cos(i * angle));
+        graphicalObjects.at(i)->getBoundingBox()->setY(centerY + radius * sin(i * angle));
+    }
+}
+
+const double getMinPositionX(std::vector<GraphicalObject*> graphicalObjects) {
+    double minX = 0.0;
+    if (graphicalObjects.size()) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+            if (graphicalObjects.at(i)->getBoundingBox()->x() < minX)
+                minX = graphicalObjects.at(i)->getBoundingBox()->x();
+    }
+
+    return minX;
+}
+
+const double getMinPositionY(std::vector<GraphicalObject*> graphicalObjects) {
+    double minY = 0.0;
+    if (graphicalObjects.size()) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+            if (graphicalObjects.at(i)->getBoundingBox()->y() < minY)
+                minY = graphicalObjects.at(i)->getBoundingBox()->y();
+    }
+
+    return minY;
+}
+
+const double getMaxPositionX(std::vector<GraphicalObject*> graphicalObjects) {
+    double maxX = 0.0;
+    if (graphicalObjects.size()) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+            if (graphicalObjects.at(i)->getBoundingBox()->x() > maxX)
+                maxX = graphicalObjects.at(i)->getBoundingBox()->x();
+    }
+
+    return maxX;
+}
+
+const double getMaxPositionY(std::vector<GraphicalObject*> graphicalObjects) {
+    double maxY = 0.0;
+    if (graphicalObjects.size()) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++)
+            if (graphicalObjects.at(i)->getBoundingBox()->y() > maxY)
+                maxY = graphicalObjects.at(i)->getBoundingBox()->y();
+    }
+
+    return maxY;
+}
+
 const bool isValidLayoutDimensionWidthValue(const double& width) {
     return isValidDimensionValue(width);
 }

--- a/src/libsbml_ne_layout_helpers.h
+++ b/src/libsbml_ne_layout_helpers.h
@@ -114,6 +114,30 @@ std::vector<SpeciesReferenceGlyph*> getSpeciesReferenceGlyphs(ReactionGlyph* rea
 
 std::vector<SpeciesReferenceGlyph*> getAssociatedSpeciesReferenceGlyphsWithReactionGlyph(ReactionGlyph* reactionGlyph);
 
+void alignGraphicalObjects(std::vector<GraphicalObject*> graphicalObjects, const std::string& alignment);
+
+void alignGraphicalObjectsToTop(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsToCenter(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsToBottom(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsToLeft(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsToMiddle(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsToRight(std::vector<GraphicalObject*> graphicalObjects);
+
+void alignGraphicalObjectsCircularly(std::vector<GraphicalObject*> graphicalObjects);
+
+const double getMinPositionX(std::vector<GraphicalObject*> graphicalObjects);
+
+const double getMinPositionY(std::vector<GraphicalObject*> graphicalObjects);
+
+const double getMaxPositionX(std::vector<GraphicalObject*> graphicalObjects);
+
+const double getMaxPositionY(std::vector<GraphicalObject*> graphicalObjects);
+
 const bool isValidLayoutDimensionWidthValue(const double& width);
 
 const bool isValidLayoutDimensionHeightValue(const double& height);

--- a/src/libsbml_ne_sbmldocument.cpp
+++ b/src/libsbml_ne_sbmldocument.cpp
@@ -58,6 +58,16 @@ namespace LIBSBML_NETWORKEDITOR_CPP_NAMESPACE  {
         return autolayout(document, 10, 15, false, false, false, getGraphicalObjectsIdsWhosePositionIsNotDependentOnGraphicalObject(getLayout(document), updateGraphicalObject));
     }
 
+    int align(SBMLDocument* document, std::vector <std::string> nodeIds,  const std::string& alignment) {
+        std::vector<GraphicalObject*> allGraphicalObjects;
+        for (unsigned int i = 0; i < nodeIds.size(); i++) {
+            std::vector<GraphicalObject*> graphicalObjects = getGraphicalObjects(document, nodeIds[i]);
+            allGraphicalObjects.insert(allGraphicalObjects.end(), graphicalObjects.begin(), graphicalObjects.end());
+        }
+        alignGraphicalObjects(allGraphicalObjects, alignment);
+        return autolayout(document, 10, 15, false, false, false, nodeIds);
+    }
+
     bool isSetId(SBase* object) {
         if (object)
             return object->isSetId();

--- a/src/libsbml_ne_sbmldocument.h
+++ b/src/libsbml_ne_sbmldocument.h
@@ -66,6 +66,13 @@ LIBSBML_NETWORKEDITOR_EXTERN int autolayout(SBMLDocument* document, const double
 /// @return integer value indicating success/failure of the function.
 LIBSBML_NETWORKEDITOR_EXTERN int updateLayoutCurves(SBMLDocument* document, GraphicalObject* updateGraphicalObject);
 
+/// @brief Align the nodes position in the SBML document in the given alignment type.
+/// @param document a pointer to the SBMLDocument object.
+/// @param nodeIds an array of node ids to be aligned.
+/// @param alignment determines how to align the nodes.
+/// @return integer value indicating success/failure of the function.
+LIBSBML_NETWORKEDITOR_EXTERN int align(SBMLDocument* document, std::vector <std::string> nodeIds,  const std::string& alignment);
+
 /// @brief Predicates returning @c true if the "id" attribute of this SBML object is set.
 /// @param object a pointer to the SBML object.
 /// @return @c true if the "id" attribute of this SBML object is set, @c false if either the "id"


### PR DESCRIPTION
Selected nodes can be aligned in the canvas using 'align' funciton. This function has an argument called 'alignment' that determines how the seleced nodes have to be aligned. Avialable options are 'top', 'center', 'bottom', 'left', 'middle', 'right', and 'circular'.