### PR TITLE
Global Styles (instead of a local style for each graphical object) are now added by default when autolayout algorithm is called

### DIFF
--- a/src/libsbmlnetwork_layout_render.cpp
+++ b/src/libsbmlnetwork_layout_render.cpp
@@ -58,11 +58,10 @@ int removeAllLocalRenderInformation(Layout* layout) {
 
 int setDefaultLocalRenderInformationFeatures(SBMLDocument* document, Layout* layout, LocalRenderInformation* localRenderInformation) {
     if (document && localRenderInformation) {
-        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(document->getLevel(), document->getVersion());
         localRenderInformation->setId("libSBMLNetwork_Local_Render");
         localRenderInformation->setReferenceRenderInformation("libSBMLNetwork_Global_Render");
         if (layout) {
-            addStyles(layout, localRenderInformation, renderPkgNamespaces);
+            addStyles(layout, localRenderInformation);
             return 0;
         }
     }

--- a/src/libsbmlnetwork_layout_render.cpp
+++ b/src/libsbmlnetwork_layout_render.cpp
@@ -61,7 +61,7 @@ int setDefaultLocalRenderInformationFeatures(SBMLDocument* document, Layout* lay
         localRenderInformation->setId("libSBMLNetwork_Local_Render");
         localRenderInformation->setReferenceRenderInformation("libSBMLNetwork_Global_Render");
         if (layout) {
-            addStyles(layout, localRenderInformation);
+            //addLocalStyles(layout, localRenderInformation);
             return 0;
         }
     }

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -3921,10 +3921,10 @@ const std::string getObjectRole(Layout* layout, const std::string& id) {
 }
 
 const std::string getObjectRole(GraphicalObject* graphicalObject) {
-    if (graphicalObject) {
-        RenderGraphicalObjectPlugin* renderGraphicalObjectPlugin = dynamic_cast<RenderGraphicalObjectPlugin*>(graphicalObject->getPlugin("render"));
-        if (renderGraphicalObjectPlugin)
-            return renderGraphicalObjectPlugin->getObjectRole();
+    if (isSpeciesReferenceGlyph(graphicalObject)) {
+        SpeciesReferenceGlyph* speciesReferenceGlyph = (SpeciesReferenceGlyph*)graphicalObject;
+        return speciesReferenceGlyph->getRoleString();
+
     }
 
     return "";

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -257,13 +257,6 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
     return colorDefinition;
 }
 
-void addTextGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
-    if (!findStyleByTypeList(globalRenderInformation, "TEXTGLYPH")) {
-        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "TEXTGLYPH");
-        setGeneralTextGlyphRenderGroupFeatures(globalStyle->createGroup());
-    }
-}
-
 void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation) {
     addProductHeadLineEnding(globalRenderInformation);
     addModifierHeadLineEnding(globalRenderInformation);
@@ -370,19 +363,25 @@ void addGlobalStyles(GlobalRenderInformation* globalRenderInformation) {
     addSpeciesGlyphGlobalStyle(globalRenderInformation);
     addReactionGlyphGlobalStyle(globalRenderInformation);
     addSpeciesReferenceGlyphGlobalStyles(globalRenderInformation);
-    //addTextGlyphGlobalStyle(globalRenderInformation);
 }
 
-GlobalStyle* createGlobalStyle(GlobalRenderInformation* globalRenderInformation, const std::string& type) {
+GlobalStyle* createGlobalStyleByType(GlobalRenderInformation* globalRenderInformation, const std::string& type) {
         GlobalStyle* globalStyle = globalRenderInformation->createGlobalStyle();
         globalStyle->setId(getGlobalStyleUniqueId(globalRenderInformation, type));
         globalStyle->addType(type);
         return globalStyle;
-    }
+}
+
+GlobalStyle* createGlobalStyleByRole(GlobalRenderInformation* globalRenderInformation, const std::string& role) {
+    GlobalStyle* globalStyle = globalRenderInformation->createGlobalStyle();
+    globalStyle->setId(getGlobalStyleUniqueId(globalRenderInformation, role));
+    globalStyle->addRole(role);
+    return globalStyle;
+}
 
 void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
     if (!findStyleByTypeList(globalRenderInformation, "COMPARTMENTGLYPH")) {
-        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "COMPARTMENTGLYPH");
+        GlobalStyle* globalStyle = createGlobalStyleByType(globalRenderInformation, "COMPARTMENTGLYPH");
         RenderGroup* renderGroup = globalStyle->createGroup();
         setCompartmentGlyphRenderGroupFeatures(renderGroup);
         setCompartmentTextGlyphRenderGroupFeatures(renderGroup);
@@ -391,7 +390,7 @@ void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInforma
 
 void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
     if (!findStyleByTypeList(globalRenderInformation, "SPECIESGLYPH")) {
-        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "SPECIESGLYPH");
+        GlobalStyle* globalStyle = createGlobalStyleByType(globalRenderInformation, "SPECIESGLYPH");
         RenderGroup* renderGroup = globalStyle->createGroup();
         setSpeciesGlyphRenderGroupFeatures(renderGroup);
         setSpeciesTextGlyphRenderGroupFeatures(renderGroup);
@@ -400,7 +399,7 @@ void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation
 
 void addReactionGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
     if (!findStyleByTypeList(globalRenderInformation, "REACTIONGLYPH")) {
-        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "REACTIONGLYPH");
+        GlobalStyle* globalStyle = createGlobalStyleByType(globalRenderInformation, "REACTIONGLYPH");
         RenderGroup* renderGroup = globalStyle->createGroup();
         setReactionGlyphRenderGroupFeatures(renderGroup);
         setReactionTextGlyphRenderGroupFeatures(renderGroup);
@@ -408,9 +407,33 @@ void addReactionGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformatio
 }
 
 void addSpeciesReferenceGlyphGlobalStyles(GlobalRenderInformation* globalRenderInformation) {
-    if (!findStyleByTypeList(globalRenderInformation, "SPECIESREFERENCEGLYPH")) {
-        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "SPECIESREFERENCEGLYPH");
+    if (!findStyleByRoleList(globalRenderInformation, "substrate")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "substrate");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_SUBSTRATE);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "sidesubstrate")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "sidesubstrate");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_SIDESUBSTRATE);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "product")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "product");
         setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_PRODUCT);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "sideproduct")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "sideproduct");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_SIDEPRODUCT);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "modifier")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "modifier");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_MODIFIER);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "activator")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "activator");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_ACTIVATOR);
+    }
+    if (!findStyleByRoleList(globalRenderInformation, "inhibitor")) {
+        GlobalStyle* globalStyle = createGlobalStyleByRole(globalRenderInformation, "inhibitor");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_INHIBITOR);
     }
 }
 

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -72,10 +72,10 @@ void enableRenderPlugin(Layout* layout) {
         layout->enablePackage(RenderExtension::getXmlnsL3V1V1(), "render", true);
 }
 
-void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
-    addCompartmentGlyphsStyles(layout, localRenderInformation, renderPkgNamespaces);
-    addSpeciesGlyphsStyles(layout, localRenderInformation, renderPkgNamespaces);
-    addReactionGlyphsStyles(layout, localRenderInformation, renderPkgNamespaces);
+void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
+    addCompartmentGlyphsStyles(layout, localRenderInformation);
+    addSpeciesGlyphsStyles(layout, localRenderInformation);
+    addReactionGlyphsStyles(layout, localRenderInformation);
 }
 
 Style* findStyleByIdList(RenderInformationBase* renderInformationBase, const std::string& id) {
@@ -172,19 +172,19 @@ const std::string getStyleType(GraphicalObject* graphicalObject) {
     return "";
 }
 
-void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
-        addCompartmentGlyphStyle(layout->getCompartmentGlyph(i), localRenderInformation, renderPkgNamespaces);
-        addCompartmentTextGlyphsStyles(layout, localRenderInformation, layout->getCompartmentGlyph(i), renderPkgNamespaces);
+        addCompartmentGlyphStyle(layout->getCompartmentGlyph(i), localRenderInformation);
+        addCompartmentTextGlyphsStyles(layout, localRenderInformation, layout->getCompartmentGlyph(i));
     }
 }
 
-void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, compartmentGlyph);
-    setCompartmentGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setCompartmentGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
+void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     Rectangle* rectangle = renderGroup->createRectangle();
     setDefaultRectangleShapeFeatures(rectangle);
     rectangle->setStroke("darkcyan");
@@ -194,109 +194,109 @@ void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgN
     rectangle->setRY(RelAbsVector(0.0, 5.0));
 }
 
-void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph, RenderPkgNamespaces* renderPkgNamespaces) {
+void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph) {
     for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
         if (layout->getTextGlyph(i)->getGraphicalObjectId() == compartmentGlyph->getId())
-            addCompartmentTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation, renderPkgNamespaces);
+            addCompartmentTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
     }
 }
 
-void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setCompartmentTextGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setCompartmentTextGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup, renderPkgNamespaces);
+void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
     renderGroup->setStroke("darkcyan");
     renderGroup->setFontSize(RelAbsVector(10.0, 0.0));
     renderGroup->setTextAnchor("middle");
     renderGroup->setVTextAnchor("bottom");
 }
 
-void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
-        addSpeciesGlyphStyle(layout->getSpeciesGlyph(i), localRenderInformation, renderPkgNamespaces);
-        addSpeciesTextGlyphsStyles(layout, localRenderInformation, layout->getSpeciesGlyph(i), renderPkgNamespaces);
+        addSpeciesGlyphStyle(layout->getSpeciesGlyph(i), localRenderInformation);
+        addSpeciesTextGlyphsStyles(layout, localRenderInformation, layout->getSpeciesGlyph(i));
     }
 }
 
-void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesGlyph);
-    setSpeciesGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setSpeciesGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
+void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     Rectangle* rectangle = renderGroup->createRectangle();
     setDefaultRectangleShapeFeatures(rectangle);
     rectangle->setRX(RelAbsVector(6, 0.0));
     rectangle->setRY(RelAbsVector(3.6, 0.0));
 }
 
-void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph) {
     for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
         if (layout->getTextGlyph(i)->getGraphicalObjectId() == speciesGlyph->getId())
-            addSpeciesTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation, renderPkgNamespaces);
+            addSpeciesTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
     }
 }
 
-void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setSpeciesTextGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setSpeciesTextGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup, renderPkgNamespaces);
+void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
     renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
 }
 
-void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
-        addReactionGlyphStyle(layout->getReactionGlyph(i), localRenderInformation, renderPkgNamespaces);
-        addReactionTextGlyphsStyles(layout, localRenderInformation, layout->getReactionGlyph(i), renderPkgNamespaces);
-        addSpeciesReferenceGlyphsStyles(layout->getReactionGlyph(i), localRenderInformation, renderPkgNamespaces);
+        addReactionGlyphStyle(layout->getReactionGlyph(i), localRenderInformation);
+        addReactionTextGlyphsStyles(layout, localRenderInformation, layout->getReactionGlyph(i));
+        addSpeciesReferenceGlyphsStyles(layout->getReactionGlyph(i), localRenderInformation);
     }
 }
 
-void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, reactionGlyph);
-    setReactionGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setReactionGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
+void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     Ellipse* ellipse = renderGroup->createEllipse();
     setDefaultEllipseShapeFeatures(ellipse);
 }
 
-void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph, RenderPkgNamespaces* renderPkgNamespaces) {
+void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph) {
     for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
         if (layout->getTextGlyph(i)->getGraphicalObjectId() == reactionGlyph->getId())
-            addReactionTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation, renderPkgNamespaces);
+            addReactionTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
     }
 }
 
-void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setReactionTextGlyphRenderGroupFeatures(localStyle->createGroup(), renderPkgNamespaces);
+    setReactionTextGlyphRenderGroupFeatures(localStyle->createGroup());
 }
 
-void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup, renderPkgNamespaces);
+void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
     renderGroup->setStroke("darkslategray");
     renderGroup->setFontSize(RelAbsVector(12.0, 0.0));
 }
 
-void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
     for (int i = 0; i < reactionGlyph->getNumSpeciesReferenceGlyphs(); i++)
-        addSpeciesReferenceGlyphStyle(reactionGlyph->getSpeciesReferenceGlyph(i), localRenderInformation, renderPkgNamespaces);
+        addSpeciesReferenceGlyphStyle(reactionGlyph->getSpeciesReferenceGlyph(i), localRenderInformation);
 }
 
-void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces) {
+void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation) {
     LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesReferenceGlyph);
-    setSpeciesReferenceGlyphRenderGroupFeatures(localStyle->createGroup(), speciesReferenceGlyph->getRole(), renderPkgNamespaces);
+    setSpeciesReferenceGlyphRenderGroupFeatures(localStyle->createGroup(), speciesReferenceGlyph->getRole());
 }
 
-void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role, RenderPkgNamespaces* renderPkgNamespaces) {
+void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role) {
     setDefault1DShapeFeatures(renderGroup);
     if (role == SPECIES_ROLE_PRODUCT || role == SPECIES_ROLE_SIDEPRODUCT)
         renderGroup->setEndHead("productHead");
@@ -315,7 +315,7 @@ LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, Gra
     return localStyle;
 }
 
-void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces) {
+void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     renderGroup->setStroke("black");
     renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
     renderGroup->setFontFamily("sans-serif");
@@ -416,26 +416,28 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
     return colorDefinition;
 }
 
-void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
-    addProductHeadLineEnding(globalRenderInformation, layoutPkgNamespaces, renderPkgNamespaces);
-    addModifierHeadLineEnding(globalRenderInformation, layoutPkgNamespaces, renderPkgNamespaces);
-    addActivatorHeadLineEnding(globalRenderInformation, layoutPkgNamespaces, renderPkgNamespaces);
-    addInhibitorHeadLineEnding(globalRenderInformation, layoutPkgNamespaces, renderPkgNamespaces);
+void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation) {
+    addProductHeadLineEnding(globalRenderInformation);
+    addModifierHeadLineEnding(globalRenderInformation);
+    addActivatorHeadLineEnding(globalRenderInformation);
+    addInhibitorHeadLineEnding(globalRenderInformation);
 }
 
-void addProductHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
-    if (!globalRenderInformation->getLineEnding("productHead"))
-        globalRenderInformation->addLineEnding(createProductHeadLineEnding(layoutPkgNamespaces, renderPkgNamespaces));
+void addProductHeadLineEnding(GlobalRenderInformation* globalRenderInformation) {
+    if (!globalRenderInformation->getLineEnding("productHead")) {
+        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(globalRenderInformation->getLevel(), globalRenderInformation->getVersion());
+        globalRenderInformation->addLineEnding(createProductHeadLineEnding(renderPkgNamespaces));
+    }
 }
 
-LineEnding* createProductHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
+LineEnding* createProductHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces) {
     LineEnding* lineEnding = new LineEnding(renderPkgNamespaces, "productHead");
-    setLineEndingGeneralFeatures(lineEnding, layoutPkgNamespaces);
-    setProductHeadLineEndingExclusiveFeatures(lineEnding, renderPkgNamespaces);
+    setLineEndingGeneralFeatures(lineEnding);
+    setProductHeadLineEndingExclusiveFeatures(lineEnding);
     return lineEnding;
 }
 
-void setProductHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces) {
+void setProductHeadLineEndingExclusiveFeatures(LineEnding* lineEnding) {
     RenderGroup* renderGroup = lineEnding->getGroup();
     Polygon* triangle = renderGroup->createPolygon();
     setDefaultTriangleShapeFeatures(triangle);
@@ -444,56 +446,62 @@ void setProductHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkg
     triangle->setFill("black");
 }
 
-void addModifierHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
-    if (!globalRenderInformation->getLineEnding("modifierHead"))
-        globalRenderInformation->addLineEnding(createModifierHeadLineEnding(layoutPkgNamespaces, renderPkgNamespaces));
+void addModifierHeadLineEnding(GlobalRenderInformation* globalRenderInformation) {
+    if (!globalRenderInformation->getLineEnding("modifierHead")) {
+        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(globalRenderInformation->getLevel(), globalRenderInformation->getVersion());
+        globalRenderInformation->addLineEnding(createModifierHeadLineEnding(renderPkgNamespaces));
+    }
 }
 
-LineEnding* createModifierHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
+LineEnding* createModifierHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces) {
     LineEnding* lineEnding = new LineEnding(renderPkgNamespaces, "modifierHead");
-    setLineEndingGeneralFeatures(lineEnding, layoutPkgNamespaces);
-    setModifierHeadLineEndingExclusiveFeatures(lineEnding, renderPkgNamespaces);
+    setLineEndingGeneralFeatures(lineEnding);
+    setModifierHeadLineEndingExclusiveFeatures(lineEnding);
     return lineEnding;
 }
 
-void setModifierHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces) {
+void setModifierHeadLineEndingExclusiveFeatures(LineEnding* lineEnding) {
     RenderGroup* renderGroup = lineEnding->getGroup();
     Ellipse* ellipse = renderGroup->createEllipse();
     setDefaultEllipseShapeFeatures(ellipse);
 }
 
-void addActivatorHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
-    if (!globalRenderInformation->getLineEnding("activatorHead"))
-        globalRenderInformation->addLineEnding(createActivatorHeadLineEnding(layoutPkgNamespaces, renderPkgNamespaces));
+void addActivatorHeadLineEnding(GlobalRenderInformation* globalRenderInformation) {
+    if (!globalRenderInformation->getLineEnding("activatorHead")) {
+        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(globalRenderInformation->getLevel(), globalRenderInformation->getVersion());
+        globalRenderInformation->addLineEnding(createActivatorHeadLineEnding(renderPkgNamespaces));
+    }
 }
 
-LineEnding* createActivatorHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
+LineEnding* createActivatorHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces) {
     LineEnding* lineEnding = new LineEnding(renderPkgNamespaces, "activatorHead");
-    setLineEndingGeneralFeatures(lineEnding, layoutPkgNamespaces);
-    setActivatorHeadLineEndingExclusiveFeatures(lineEnding, renderPkgNamespaces);
+    setLineEndingGeneralFeatures(lineEnding);
+    setActivatorHeadLineEndingExclusiveFeatures(lineEnding);
     return lineEnding;
 }
 
-void setActivatorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces) {
+void setActivatorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding) {
     RenderGroup* renderGroup = lineEnding->getGroup();
     Polygon* diamond = renderGroup->createPolygon();
     setDefaultDiamondShapeFeatures(diamond);
 }
 
-void addInhibitorHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
-    if (!globalRenderInformation->getLineEnding("inhibitorHead"))
-        globalRenderInformation->addLineEnding(createInhibitorHeadLineEnding(layoutPkgNamespaces, renderPkgNamespaces));
+void addInhibitorHeadLineEnding(GlobalRenderInformation* globalRenderInformation) {
+    if (!globalRenderInformation->getLineEnding("inhibitorHead")) {
+        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(globalRenderInformation->getLevel(), globalRenderInformation->getVersion());
+        globalRenderInformation->addLineEnding(createInhibitorHeadLineEnding(renderPkgNamespaces));
+    }
 }
 
-LineEnding* createInhibitorHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces) {
+LineEnding* createInhibitorHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces) {
     LineEnding* lineEnding = new LineEnding(renderPkgNamespaces, "inhibitorHead");
     lineEnding->createGroup();
-    setLineEndingGeneralFeatures(lineEnding, layoutPkgNamespaces);
-    setInhibitorHeadLineEndingExclusiveFeatures(lineEnding, renderPkgNamespaces);
+    setLineEndingGeneralFeatures(lineEnding);
+    setInhibitorHeadLineEndingExclusiveFeatures(lineEnding);
     return lineEnding;
 }
 
-void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces) {
+void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding) {
     RenderGroup* renderGroup = lineEnding->getGroup();
     Rectangle* rectangle = renderGroup->createRectangle();
     setDefaultRectangleShapeFeatures(rectangle);
@@ -503,8 +511,9 @@ void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderP
     rectangle->setRY(RelAbsVector(0.0, 0.0));
 }
 
-void setLineEndingGeneralFeatures(LineEnding* lineEnding, LayoutPkgNamespaces* layoutPkgNamespaces) {
+void setLineEndingGeneralFeatures(LineEnding* lineEnding) {
     lineEnding->setEnableRotationalMapping(true);
+    LayoutPkgNamespaces* layoutPkgNamespaces = new LayoutPkgNamespaces(lineEnding->getLevel(), lineEnding->getVersion());
     lineEnding->setBoundingBox(new BoundingBox(layoutPkgNamespaces, lineEnding->getId() + "_bb", -12.0, -6.0, 12.0, 12.0));
 }
 

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -72,12 +72,6 @@ void enableRenderPlugin(Layout* layout) {
         layout->enablePackage(RenderExtension::getXmlnsL3V1V1(), "render", true);
 }
 
-void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
-    addCompartmentGlyphsStyles(layout, localRenderInformation);
-    addSpeciesGlyphsStyles(layout, localRenderInformation);
-    addReactionGlyphsStyles(layout, localRenderInformation);
-}
-
 Style* findStyleByIdList(RenderInformationBase* renderInformationBase, const std::string& id) {
     if (renderInformationBase->isLocalRenderInformation())
         return findStyleByIdList((LocalRenderInformation*)renderInformationBase, id);
@@ -172,159 +166,6 @@ const std::string getStyleType(GraphicalObject* graphicalObject) {
     return "";
 }
 
-void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
-    for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
-        addCompartmentGlyphStyle(layout->getCompartmentGlyph(i), localRenderInformation);
-        addCompartmentTextGlyphsStyles(layout, localRenderInformation, layout->getCompartmentGlyph(i));
-    }
-}
-
-void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, compartmentGlyph);
-    setCompartmentGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    Rectangle* rectangle = renderGroup->createRectangle();
-    setDefaultRectangleShapeFeatures(rectangle);
-    rectangle->setStroke("darkcyan");
-    rectangle->setStrokeWidth(2.0);
-    rectangle->setFill("lightgray");
-    rectangle->setRX(RelAbsVector(0.0, 5.0));
-    rectangle->setRY(RelAbsVector(0.0, 5.0));
-}
-
-void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph) {
-    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
-        if (layout->getTextGlyph(i)->getGraphicalObjectId() == compartmentGlyph->getId())
-            addCompartmentTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
-    }
-}
-
-void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setCompartmentTextGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
-    renderGroup->setStroke("darkcyan");
-    renderGroup->setFontSize(RelAbsVector(10.0, 0.0));
-    renderGroup->setTextAnchor("middle");
-    renderGroup->setVTextAnchor("bottom");
-}
-
-void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
-    for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
-        addSpeciesGlyphStyle(layout->getSpeciesGlyph(i), localRenderInformation);
-        addSpeciesTextGlyphsStyles(layout, localRenderInformation, layout->getSpeciesGlyph(i));
-    }
-}
-
-void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesGlyph);
-    setSpeciesGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    Rectangle* rectangle = renderGroup->createRectangle();
-    setDefaultRectangleShapeFeatures(rectangle);
-    rectangle->setRX(RelAbsVector(6, 0.0));
-    rectangle->setRY(RelAbsVector(3.6, 0.0));
-}
-
-void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph) {
-    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
-        if (layout->getTextGlyph(i)->getGraphicalObjectId() == speciesGlyph->getId())
-            addSpeciesTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
-    }
-}
-
-void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setSpeciesTextGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
-    renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
-}
-
-void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
-    for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
-        addReactionGlyphStyle(layout->getReactionGlyph(i), localRenderInformation);
-        addReactionTextGlyphsStyles(layout, localRenderInformation, layout->getReactionGlyph(i));
-        addSpeciesReferenceGlyphsStyles(layout->getReactionGlyph(i), localRenderInformation);
-    }
-}
-
-void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, reactionGlyph);
-    setReactionGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    Ellipse* ellipse = renderGroup->createEllipse();
-    setDefaultEllipseShapeFeatures(ellipse);
-}
-
-void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph) {
-    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
-        if (layout->getTextGlyph(i)->getGraphicalObjectId() == reactionGlyph->getId())
-            addReactionTextGlyphStyle(layout->getTextGlyph(i), localRenderInformation);
-    }
-}
-
-void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
-    setReactionTextGlyphRenderGroupFeatures(localStyle->createGroup());
-}
-
-void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
-    renderGroup->setStroke("darkslategray");
-    renderGroup->setFontSize(RelAbsVector(12.0, 0.0));
-}
-
-void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
-    for (int i = 0; i < reactionGlyph->getNumSpeciesReferenceGlyphs(); i++)
-        addSpeciesReferenceGlyphStyle(reactionGlyph->getSpeciesReferenceGlyph(i), localRenderInformation);
-}
-
-void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation) {
-    LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesReferenceGlyph);
-    setSpeciesReferenceGlyphRenderGroupFeatures(localStyle->createGroup(), speciesReferenceGlyph->getRole());
-}
-
-void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role) {
-    setDefault1DShapeFeatures(renderGroup);
-    if (role == SPECIES_ROLE_PRODUCT || role == SPECIES_ROLE_SIDEPRODUCT)
-        renderGroup->setEndHead("productHead");
-    else if (role == SPECIES_ROLE_MODIFIER)
-        renderGroup->setEndHead("modifierHead");
-    else if (role == SPECIES_ROLE_ACTIVATOR)
-        renderGroup->setEndHead("activatorHead");
-    else if (role == SPECIES_ROLE_INHIBITOR)
-        renderGroup->setEndHead("inhibitorHead");
-}
-
-LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, GraphicalObject* graphicalObject) {
-    LocalStyle* localStyle = localRenderInformation->createLocalStyle();
-    localStyle->setId(graphicalObject->getId() + "_style");
-    localStyle->addId(graphicalObject->getId());
-    return localStyle;
-}
-
-void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
-    renderGroup->setStroke("black");
-    renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
-    renderGroup->setFontFamily("sans-serif");
-    renderGroup->setFontWeight("normal");
-    renderGroup->setFontStyle("normal");
-    renderGroup->setTextAnchor("middle");
-    renderGroup->setVTextAnchor("middle");
-}
-
 void addDefaultColors(GlobalRenderInformation* globalRenderInformation) {
     addColor(globalRenderInformation, "white");
     addColor(globalRenderInformation, "black");
@@ -414,6 +255,13 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
     ColorDefinition* colorDefinition = new ColorDefinition(renderPkgNamespaces, id);
     colorDefinition->setValue(value);
     return colorDefinition;
+}
+
+void addTextGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, "TEXTGLYPH")) {
+        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "TEXTGLYPH");
+        setGeneralTextGlyphRenderGroupFeatures(globalStyle->createGroup());
+    }
 }
 
 void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation) {
@@ -515,6 +363,215 @@ void setLineEndingGeneralFeatures(LineEnding* lineEnding) {
     lineEnding->setEnableRotationalMapping(true);
     LayoutPkgNamespaces* layoutPkgNamespaces = new LayoutPkgNamespaces(lineEnding->getLevel(), lineEnding->getVersion());
     lineEnding->setBoundingBox(new BoundingBox(layoutPkgNamespaces, lineEnding->getId() + "_bb", -12.0, -6.0, 12.0, 12.0));
+}
+
+void addGlobalStyles(GlobalRenderInformation* globalRenderInformation) {
+    addCompartmentGlyphGlobalStyle(globalRenderInformation);
+    addSpeciesGlyphGlobalStyle(globalRenderInformation);
+    addReactionGlyphGlobalStyle(globalRenderInformation);
+    addSpeciesReferenceGlyphGlobalStyles(globalRenderInformation);
+    //addTextGlyphGlobalStyle(globalRenderInformation);
+}
+
+GlobalStyle* createGlobalStyle(GlobalRenderInformation* globalRenderInformation, const std::string& type) {
+        GlobalStyle* globalStyle = globalRenderInformation->createGlobalStyle();
+        globalStyle->setId(getGlobalStyleUniqueId(globalRenderInformation, type));
+        globalStyle->addType(type);
+        return globalStyle;
+    }
+
+void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, "COMPARTMENTGLYPH")) {
+        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "COMPARTMENTGLYPH");
+        RenderGroup* renderGroup = globalStyle->createGroup();
+        setCompartmentGlyphRenderGroupFeatures(renderGroup);
+        setCompartmentTextGlyphRenderGroupFeatures(renderGroup);
+    }
+}
+
+void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, "SPECIESGLYPH")) {
+        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "SPECIESGLYPH");
+        RenderGroup* renderGroup = globalStyle->createGroup();
+        setSpeciesGlyphRenderGroupFeatures(renderGroup);
+        setSpeciesTextGlyphRenderGroupFeatures(renderGroup);
+    }
+}
+
+void addReactionGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, "REACTIONGLYPH")) {
+        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "REACTIONGLYPH");
+        RenderGroup* renderGroup = globalStyle->createGroup();
+        setReactionGlyphRenderGroupFeatures(renderGroup);
+        setReactionTextGlyphRenderGroupFeatures(renderGroup);
+    }
+}
+
+void addSpeciesReferenceGlyphGlobalStyles(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, "SPECIESREFERENCEGLYPH")) {
+        GlobalStyle* globalStyle = createGlobalStyle(globalRenderInformation, "SPECIESREFERENCEGLYPH");
+        setSpeciesReferenceGlyphRenderGroupFeatures(globalStyle->createGroup(), SPECIES_ROLE_PRODUCT);
+    }
+}
+
+void addLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
+    addCompartmentGlyphsLocalStyles(layout, localRenderInformation);
+    addSpeciesGlyphsLocalStyles(layout, localRenderInformation);
+    addReactionGlyphsLocalStyles(layout, localRenderInformation);
+}
+
+LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, GraphicalObject* graphicalObject) {
+        LocalStyle* localStyle = localRenderInformation->createLocalStyle();
+        localStyle->setId(graphicalObject->getId() + "_style");
+        localStyle->addId(graphicalObject->getId());
+        return localStyle;
+    }
+
+void addCompartmentGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
+    for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
+        addCompartmentGlyphLocalStyle(layout->getCompartmentGlyph(i), localRenderInformation);
+        addCompartmentTextGlyphsLocalStyles(layout, localRenderInformation, layout->getCompartmentGlyph(i));
+    }
+}
+
+void addCompartmentGlyphLocalStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, compartmentGlyph);
+    setCompartmentGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addCompartmentTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph) {
+    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
+        if (layout->getTextGlyph(i)->getGraphicalObjectId() == compartmentGlyph->getId())
+            addCompartmentTextGlyphLocalStyle(layout->getTextGlyph(i), localRenderInformation);
+    }
+}
+
+void addCompartmentTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
+    setCompartmentTextGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addSpeciesGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
+    for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
+        addSpeciesGlyphLocalStyle(layout->getSpeciesGlyph(i), localRenderInformation);
+        addSpeciesTextGlyphsLocalStyles(layout, localRenderInformation, layout->getSpeciesGlyph(i));
+    }
+}
+
+void addSpeciesGlyphLocalStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesGlyph);
+    setSpeciesGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addSpeciesTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph) {
+    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
+        if (layout->getTextGlyph(i)->getGraphicalObjectId() == speciesGlyph->getId())
+            addSpeciesTextGlyphLocalStyle(layout->getTextGlyph(i), localRenderInformation);
+    }
+}
+
+void addSpeciesTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
+    setSpeciesTextGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addReactionGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation) {
+    for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
+        addReactionGlyphLocalStyle(layout->getReactionGlyph(i), localRenderInformation);
+        addReactionTextGlyphsLocalStyles(layout, localRenderInformation, layout->getReactionGlyph(i));
+        addSpeciesReferenceGlyphsLocalStyles(layout->getReactionGlyph(i), localRenderInformation);
+    }
+}
+
+void addReactionGlyphLocalStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, reactionGlyph);
+    setReactionGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addReactionTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph) {
+    for (unsigned int i = 0; i < layout->getNumTextGlyphs(); i++) {
+        if (layout->getTextGlyph(i)->getGraphicalObjectId() == reactionGlyph->getId())
+            addReactionTextGlyphLocalStyle(layout->getTextGlyph(i), localRenderInformation);
+    }
+}
+
+void addReactionTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, textGlyph);
+    setReactionTextGlyphRenderGroupFeatures(localStyle->createGroup());
+}
+
+void addSpeciesReferenceGlyphsLocalStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation) {
+    for (int i = 0; i < reactionGlyph->getNumSpeciesReferenceGlyphs(); i++)
+        addSpeciesReferenceGlyphLocalStyle(reactionGlyph->getSpeciesReferenceGlyph(i), localRenderInformation);
+}
+
+void addSpeciesReferenceGlyphLocalStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation) {
+    LocalStyle* localStyle = createLocalStyle(localRenderInformation, speciesReferenceGlyph);
+    setSpeciesReferenceGlyphRenderGroupFeatures(localStyle->createGroup(), speciesReferenceGlyph->getRole());
+}
+
+void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    Rectangle* rectangle = renderGroup->createRectangle();
+    setDefaultRectangleShapeFeatures(rectangle);
+    rectangle->setStroke("darkcyan");
+    rectangle->setStrokeWidth(2.0);
+    rectangle->setFill("lightgray");
+    rectangle->setRX(RelAbsVector(0.0, 5.0));
+    rectangle->setRY(RelAbsVector(0.0, 5.0));
+}
+
+void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
+    renderGroup->setStroke("darkcyan");
+    renderGroup->setFontSize(RelAbsVector(10.0, 0.0));
+    renderGroup->setTextAnchor("middle");
+    renderGroup->setVTextAnchor("bottom");
+}
+
+void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    Rectangle* rectangle = renderGroup->createRectangle();
+    setDefaultRectangleShapeFeatures(rectangle);
+    rectangle->setRX(RelAbsVector(6, 0.0));
+    rectangle->setRY(RelAbsVector(3.6, 0.0));
+}
+
+
+void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
+    renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
+}
+
+void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    Ellipse* ellipse = renderGroup->createEllipse();
+    setDefaultEllipseShapeFeatures(ellipse);
+}
+
+void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    setGeneralTextGlyphRenderGroupFeatures(renderGroup);
+    renderGroup->setStroke("darkslategray");
+    renderGroup->setFontSize(RelAbsVector(12.0, 0.0));
+}
+
+void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role) {
+    setDefault1DShapeFeatures(renderGroup);
+    if (role == SPECIES_ROLE_PRODUCT || role == SPECIES_ROLE_SIDEPRODUCT)
+        renderGroup->setEndHead("productHead");
+    else if (role == SPECIES_ROLE_MODIFIER)
+        renderGroup->setEndHead("modifierHead");
+    else if (role == SPECIES_ROLE_ACTIVATOR)
+        renderGroup->setEndHead("activatorHead");
+    else if (role == SPECIES_ROLE_INHIBITOR)
+        renderGroup->setEndHead("inhibitorHead");
+}
+
+void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    renderGroup->setStroke("black");
+    renderGroup->setFontSize(RelAbsVector(24.0, 0.0));
+    renderGroup->setFontFamily("sans-serif");
+    renderGroup->setFontWeight("normal");
+    renderGroup->setFontStyle("normal");
+    renderGroup->setTextAnchor("middle");
+    renderGroup->setVTextAnchor("middle");
 }
 
 void setDefault1DShapeFeatures(GraphicalPrimitive1D* graphicalPrimitive1D) {
@@ -669,6 +726,13 @@ void setDefaultImageShapeFeatures(Image* image) {
     image->setY(RelAbsVector(0.0, 0.0));
     image->setWidth(RelAbsVector(0.0, 100.0));
     image->setHeight(RelAbsVector(0.0, 100.0));
+}
+
+const std::string getGlobalStyleUniqueId(GlobalRenderInformation* globalRenderInformation, const std::string& type) {
+    unsigned int global_style_iterator = 0;
+    while (globalRenderInformation->getGlobalStyle(type + "_style_" + std::to_string(global_style_iterator)))
+        global_style_iterator++;
+    return type + "_style_" + std::to_string(global_style_iterator);
 }
 
 const bool isValidBackgroundColorValue(const std::string& backgroundColor) {

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -25,7 +25,7 @@ void enableRenderPlugin(SBMLDocument* document);
 
 void enableRenderPlugin(Layout* layout);
 
-void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
 
 Style* findStyleByIdList(RenderInformationBase* renderInformationBase, const std::string& id);
 
@@ -45,51 +45,51 @@ Style* findStyleByTypeList(GlobalRenderInformation* globalRenderInformation, con
 
 const std::string getStyleType(GraphicalObject* graphicalObject);
 
-void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
 
-void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation);
 
-void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph, RenderPkgNamespaces* renderPkgNamespaces);
+void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph);
 
-void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
 
-void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
 
-void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation);
 
-void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph);
 
-void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
 
-void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
 
-void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
 
-void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph, RenderPkgNamespaces* renderPkgNamespaces);
+void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph);
 
-void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
 
-void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
-void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
 
-void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation, RenderPkgNamespaces* renderPkgNamespaces);
+void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation);
 
-void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role, RenderPkgNamespaces* renderPkgNamespaces);
+void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role);
 
 LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, GraphicalObject* graphicalObject);
 
-void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup, RenderPkgNamespaces* renderPkgNamespaces);
+void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
 void addDefaultColors(GlobalRenderInformation* globalRenderInformation);
 
@@ -107,33 +107,33 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
 
 ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, const std::string &value);
 
-void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation);
 
-void addProductHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+void addProductHeadLineEnding(GlobalRenderInformation* globalRenderInformation);
 
-LineEnding* createProductHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+LineEnding* createProductHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces);
 
-void setProductHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces);
+void setProductHeadLineEndingExclusiveFeatures(LineEnding* lineEnding);
 
-void addModifierHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+void addModifierHeadLineEnding(GlobalRenderInformation* globalRenderInformation);
 
-LineEnding* createModifierHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+LineEnding* createModifierHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces);
 
-void setModifierHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces);
+void setModifierHeadLineEndingExclusiveFeatures(LineEnding* lineEnding);
 
-void addActivatorHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+void addActivatorHeadLineEnding(GlobalRenderInformation* globalRenderInformation);
 
-LineEnding* createActivatorHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+LineEnding* createActivatorHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces);
 
-void setActivatorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces);
+void setActivatorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding);
 
-void addInhibitorHeadLineEnding(GlobalRenderInformation* globalRenderInformation, LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+void addInhibitorHeadLineEnding(GlobalRenderInformation* globalRenderInformation);
 
-LineEnding* createInhibitorHeadLineEnding(LayoutPkgNamespaces* layoutPkgNamespaces, RenderPkgNamespaces* renderPkgNamespaces);
+LineEnding* createInhibitorHeadLineEnding(RenderPkgNamespaces* renderPkgNamespaces);
 
-void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding, RenderPkgNamespaces* renderPkgNamespaces);
+void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding);
 
-void setLineEndingGeneralFeatures(LineEnding* lineEnding, LayoutPkgNamespaces* layoutPkgNamespaces);
+void setLineEndingGeneralFeatures(LineEnding* lineEnding);
 
 void setDefault1DShapeFeatures(GraphicalPrimitive1D* graphicalPrimitive1D);
 

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -93,7 +93,9 @@ void setLineEndingGeneralFeatures(LineEnding* lineEnding);
 
 void addGlobalStyles(GlobalRenderInformation* globalRenderInformation);
 
-GlobalStyle* createGlobalStyle(GlobalRenderInformation* globalRenderInformation, const std::string& type);
+GlobalStyle* createGlobalStyleByType(GlobalRenderInformation* globalRenderInformation, const std::string& type);
+
+GlobalStyle* createGlobalStyleByRole(GlobalRenderInformation* globalRenderInformation, const std::string& role);
 
 void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
 

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -25,8 +25,6 @@ void enableRenderPlugin(SBMLDocument* document);
 
 void enableRenderPlugin(Layout* layout);
 
-void addStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
-
 Style* findStyleByIdList(RenderInformationBase* renderInformationBase, const std::string& id);
 
 Style* findStyleByIdList(LocalRenderInformation* localRenderInformation, const std::string& id);
@@ -45,50 +43,6 @@ Style* findStyleByTypeList(GlobalRenderInformation* globalRenderInformation, con
 
 const std::string getStyleType(GraphicalObject* graphicalObject);
 
-void addCompartmentGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
-
-void addCompartmentGlyphStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation);
-
-void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addCompartmentTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph);
-
-void addCompartmentTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
-
-void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addSpeciesGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
-
-void addSpeciesGlyphStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation);
-
-void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addSpeciesTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph);
-
-void addSpeciesTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
-
-void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addReactionGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
-
-void addReactionGlyphStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
-
-void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addReactionTextGlyphsStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph);
-
-void addReactionTextGlyphStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
-
-void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
-
-void addSpeciesReferenceGlyphsStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
-
-void addSpeciesReferenceGlyphStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation);
-
-void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role);
-
-LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, GraphicalObject* graphicalObject);
-
 void setGeneralTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
 void addDefaultColors(GlobalRenderInformation* globalRenderInformation);
@@ -103,9 +57,11 @@ const bool addColor(SBMLDocument* document, LineEnding* lineEnding, const std::s
 
 const bool addColor(RenderInformationBase* renderInformationBase, const std::string &color);
 
-ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, unsigned char r, unsigned char g, unsigned char b, unsigned char a = 255);
+ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 
 ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, const std::string &value);
+
+void addTextGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
 
 void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation);
 
@@ -135,6 +91,68 @@ void setInhibitorHeadLineEndingExclusiveFeatures(LineEnding* lineEnding);
 
 void setLineEndingGeneralFeatures(LineEnding* lineEnding);
 
+void addGlobalStyles(GlobalRenderInformation* globalRenderInformation);
+
+GlobalStyle* createGlobalStyle(GlobalRenderInformation* globalRenderInformation, const std::string& type);
+
+void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
+
+void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
+
+void addReactionGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
+
+void addSpeciesReferenceGlyphGlobalStyles(GlobalRenderInformation* globalRenderInformation);
+
+void addLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
+
+LocalStyle* createLocalStyle(LocalRenderInformation* localRenderInformation, GraphicalObject* graphicalObject);
+
+void addCompartmentGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
+
+void addCompartmentGlyphLocalStyle(CompartmentGlyph* compartmentGlyph, LocalRenderInformation* localRenderInformation);
+
+void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void addCompartmentTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, CompartmentGlyph* compartmentGlyph);
+
+void addCompartmentTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
+
+void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void addSpeciesGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
+
+void addSpeciesGlyphLocalStyle(SpeciesGlyph* speciesGlyph, LocalRenderInformation* localRenderInformation);
+
+void addSpeciesTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, SpeciesGlyph* speciesGlyph);
+
+void addSpeciesTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
+
+void addReactionGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation);
+
+void addReactionGlyphLocalStyle(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
+
+void addReactionTextGlyphsLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformation, ReactionGlyph* reactionGlyph);
+
+void addReactionTextGlyphLocalStyle(TextGlyph* textGlyph, LocalRenderInformation* localRenderInformation);
+
+void addSpeciesReferenceGlyphsLocalStyles(ReactionGlyph* reactionGlyph, LocalRenderInformation* localRenderInformation);
+
+void addSpeciesReferenceGlyphLocalStyle(SpeciesReferenceGlyph* speciesReferenceGlyph, LocalRenderInformation* localRenderInformation);
+
+void setCompartmentGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setCompartmentTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setSpeciesTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setReactionTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
+void setSpeciesReferenceGlyphRenderGroupFeatures(RenderGroup* renderGroup, SpeciesReferenceRole_t role);
+
 void setDefault1DShapeFeatures(GraphicalPrimitive1D* graphicalPrimitive1D);
 
 void setDefault2DShapeFeatures(GraphicalPrimitive2D* graphicalPrimitive2D);
@@ -156,6 +174,8 @@ void setDefaultOctagonShapeFeatures(Polygon* pentagon);
 void setDefaultRenderCurveShapeFeatures(RenderCurve* renderCurve);
 
 void setDefaultImageShapeFeatures(Image* image);
+
+const std::string getGlobalStyleUniqueId(GlobalRenderInformation* globalRenderInformation, const std::string& type);
 
 const bool isValidBackgroundColorValue(const std::string& backgroundColor);
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -61,12 +61,10 @@ int removeAllGlobalRenderInformation(SBMLDocument* document) {
 
 int setDefaultGlobalRenderInformationFeatures(SBMLDocument* document, GlobalRenderInformation* globalRenderInformation) {
     if (document && globalRenderInformation) {
-        LayoutPkgNamespaces* layoutPkgNamespaces = new LayoutPkgNamespaces(document->getLevel(), document->getVersion());
-        RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(document->getLevel(), document->getVersion());
         globalRenderInformation->setId("libSBMLNetwork_Global_Render");
         globalRenderInformation->setBackgroundColor("white");
         addDefaultColors(globalRenderInformation);
-        addDefaultLineEndings(globalRenderInformation, layoutPkgNamespaces, renderPkgNamespaces);
+        addDefaultLineEndings(globalRenderInformation);
         return 0;
     }
 
@@ -129,7 +127,7 @@ int createDefaultLocalRenderInformation(SBMLDocument* document) {
     Layout* layout = getLayout(document);
     if (!getNumLocalRenderInformation(layout)) {
         LocalRenderInformation* localRenderInformation = createLocalRenderInformation(layout);
-        return setDefaultLocalRenderInformationFeatures(document,layout, localRenderInformation);
+        return setDefaultLocalRenderInformationFeatures(document, layout, localRenderInformation);
     }
 
     return -1;

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -65,6 +65,7 @@ int setDefaultGlobalRenderInformationFeatures(SBMLDocument* document, GlobalRend
         globalRenderInformation->setBackgroundColor("white");
         addDefaultColors(globalRenderInformation);
         addDefaultLineEndings(globalRenderInformation);
+        addGlobalStyles(globalRenderInformation);
         return 0;
     }
 


### PR DESCRIPTION
-  setDefaultLocalRenderInformationFeatures no longer calls addLocalStyles
-  addGlobalStyles is called inside setDefaultGlobalRenderInformationFeatures function
- Functions related to add style for a specific model entity are now split up to local and global ones
- global styles are now also created by role to be used by species reference glyphs
- text glyph type of global style is deprecated
- getObjectRole function is debugged so that it only returns the role of the species reference glyphs if exists
