### PR TITLE
Fix the issue with passing the id of a non-enitty object

### DIFF
--- a/docs/api_reference/c_api_index.rst
+++ b/docs/api_reference/c_api_index.rst
@@ -743,7 +743,11 @@ Functions
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_isRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0)
 
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_isSquare(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0)
+
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_isEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0)
+
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_isCircle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0)
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_isPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0)
 

--- a/docs/api_reference/cpp_api_index.rst
+++ b/docs/api_reference/cpp_api_index.rst
@@ -1750,9 +1750,17 @@ Render Functions
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isRectangle(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0)
 
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isSquare(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0)
+
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isSquare(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0)
+
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isEllipse(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0)
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isEllipse(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0)
+
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isCircle(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0)
+
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isCircle(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0)
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::isPolygon(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0)
 

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -6120,7 +6120,25 @@ class LibSBMLNetwork:
         """
         return lib.c_api_removeGeometricShape(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
 
-    def setGeometricShape(self, id, geometric_shape, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+    def getGeometricShapeType(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns the type of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the type of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+        """
+        lib.c_api_getGeometricShapeType.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getGeometricShapeType(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)).value.decode()
+
+    def setGeometricShapeType(self, id, geometric_shape, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
         """
         Sets the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
 
@@ -6136,9 +6154,9 @@ class LibSBMLNetwork:
 
             true on success and false if the GeometricShape object could not be set
         """
-        return lib.c_api_setGeometricShape(self.sbml_object, str(id).encode(), str(geometric_shape).encode(), geometric_shape_index, graphical_object_index, layout_index)
+        return lib.c_api_setGeometricShapeType(self.sbml_object, str(id).encode(), str(geometric_shape).encode(), geometric_shape_index, graphical_object_index, layout_index)
 
-    def setCompartmentsGeometricShapes(self, geometric_shape, layout_index=0):
+    def setCompartmentsGeometricShapesType(self, geometric_shape, layout_index=0):
         """
         Sets the GeometricShape object associated with the compartments in the given SBMLDocument
 
@@ -6151,9 +6169,9 @@ class LibSBMLNetwork:
 
             true on success and false if the GeometricShape object could not be set
         """
-        return lib.c_api_setCompartmentsGeometricShapes(self.sbml_object, str(geometric_shape).encode(), layout_index)
+        return lib.c_api_setCompartmentsGeometricShapesType(self.sbml_object, str(geometric_shape).encode(), layout_index)
 
-    def setSpeciesGeometricShapes(self, geometric_shape, layout_index=0):
+    def setSpeciesGeometricShapesType(self, geometric_shape, layout_index=0):
         """
         Sets the GeometricShape object associated with the species in the given SBMLDocument
 
@@ -6166,9 +6184,9 @@ class LibSBMLNetwork:
 
             true on success and false if the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesGeometricShapes(self.sbml_object, str(geometric_shape).encode(), layout_index)
+        return lib.c_api_setSpeciesGeometricShapesType(self.sbml_object, str(geometric_shape).encode(), layout_index)
 
-    def setReactionsGeometricShapes(self, geometric_shape, layout_index=0):
+    def setReactionsGeometricShapesType(self, geometric_shape, layout_index=0):
         """
         Sets the GeometricShape object associated with the reaction in the given SBMLDocument
 
@@ -6181,9 +6199,9 @@ class LibSBMLNetwork:
 
             true on success and false if the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionsGeometricShapes(self.sbml_object, str(geometric_shape).encode(), layout_index)
+        return lib.c_api_setReactionsGeometricShapesType(self.sbml_object, str(geometric_shape).encode(), layout_index)
 
-    def setGeometricShapes(self, geometric_shape, layout_index=0):
+    def setGeometricShapesType(self, geometric_shape, layout_index=0):
         """
         Sets the GeometricShape object associated with the model entity in the given SBMLDocument
 
@@ -6196,7 +6214,7 @@ class LibSBMLNetwork:
 
             true on success and false if the GeometricShape object could not be set
         """
-        return lib.c_api_setGeometricShapes(self.sbml_object, str(geometric_shape).encode(), layout_index)
+        return lib.c_api_setGeometricShapesType(self.sbml_object, str(geometric_shape).encode(), layout_index)
 
     def isRectangle(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
         """
@@ -6215,6 +6233,23 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isRectangle(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
 
+    def isSquare(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns whether the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is a Square object
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is a Square object and false otherwise
+        """
+        return lib.c_api_isSquare(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
     def isEllipse(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
         """
         Returns whether the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is an Ellipse object
@@ -6231,6 +6266,23 @@ class LibSBMLNetwork:
             true if the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is an Ellipse object and false otherwise
         """
         return lib.c_api_isEllipse(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def isCircle(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns whether the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is a Circle object
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is a Circle object and false otherwise
+        """
+        return lib.c_api_isCircle(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
 
     def isPolygon(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/sbmlnetwork/tests/test_sbml_network.py
+++ b/src/bindings/python/ctypes/sbmlnetwork/tests/test_sbml_network.py
@@ -453,7 +453,7 @@ class TestSBMLNetwork(unittest.TestCase):
             network.setSpeciesGeometricShapesType('square')
             list_of_species_ids = network.getListOfSpeciesIds()
             for species_id in list_of_species_ids:
-                self.assertEqual(True, bool(network.isSqaure(species_id)))
+                self.assertEqual(True, bool(network.isSquare(species_id)))
                 self.assertEqual("square", network.getGeometricShapeType(species_id))
 
     def test_move_rectangle_geometric_shape(self):
@@ -466,7 +466,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             x = 10.0
             y = 15.0
-            network.setSpeciesGeometricShapes('rectangle')
+            network.setSpeciesGeometricShapesType('rectangle')
             network.setSpeciesGeometricShapeXs(x)
             network.setSpeciesGeometricShapeYs(y)
             list_of_species_ids = network.getListOfSpeciesIds()
@@ -484,7 +484,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             width = 10.0
             height = 15.0
-            network.setSpeciesGeometricShapes('rectangle')
+            network.setSpeciesGeometricShapesType('rectangle')
             network.setSpeciesGeometricShapeWidths(width)
             network.setSpeciesGeometricShapeHeights(height)
             list_of_species_ids = network.getListOfSpeciesIds()
@@ -503,7 +503,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             center_x = 5.0
             center_y = 7.5
-            network.setSpeciesGeometricShapes('ellipse')
+            network.setSpeciesGeometricShapesType('ellipse')
             network.setSpeciesGeometricShapeCenterXs(center_x)
             network.setSpeciesGeometricShapeCenterYs(center_y)
             list_of_species_ids = network.getListOfSpeciesIds()
@@ -522,7 +522,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             radius_x = 5.0
             radius_y = 7.5
-            network.setSpeciesGeometricShapes('ellipse')
+            network.setSpeciesGeometricShapesType('ellipse')
             network.setSpeciesGeometricShapeRadiusXs(radius_x)
             network.setSpeciesGeometricShapeRadiusYs(radius_y)
             list_of_species_ids = network.getListOfSpeciesIds()

--- a/src/bindings/python/ctypes/sbmlnetwork/tests/test_sbml_network.py
+++ b/src/bindings/python/ctypes/sbmlnetwork/tests/test_sbml_network.py
@@ -444,15 +444,17 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             list_of_species_ids = network.getListOfSpeciesIds()
             for species_id in list_of_species_ids:
-                network.setGeometricShape(species_id, 'ellipse')
+                network.setGeometricShapeType(species_id, 'ellipse')
                 self.assertEqual(True, bool(network.isEllipse(species_id)))
+                self.assertEqual("ellipse", network.getGeometricShapeType(species_id))
 
     def test_set_geometric_shapes(self):
         for network in self.networks:
-            network.setSpeciesGeometricShapes('rectangle')
+            network.setSpeciesGeometricShapesType('square')
             list_of_species_ids = network.getListOfSpeciesIds()
             for species_id in list_of_species_ids:
-                self.assertEqual(True, bool(network.isRectangle(species_id)))
+                self.assertEqual(True, bool(network.isSqaure(species_id)))
+                self.assertEqual("square", network.getGeometricShapeType(species_id))
 
     def test_move_rectangle_geometric_shape(self):
         for network in self.networks:
@@ -494,7 +496,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             list_of_species_ids = network.getListOfSpeciesIds()
             for species_id in list_of_species_ids:
-                network.setGeometricShape(species_id, 'ellipse')
+                network.setGeometricShapeType(species_id, 'ellipse')
                 self._check_move_ellipse_geometric_shape(network, species_id)
 
     def test_move_ellipse_geometric_shapes(self):
@@ -513,7 +515,7 @@ class TestSBMLNetwork(unittest.TestCase):
         for network in self.networks:
             list_of_species_ids = network.getListOfSpeciesIds()
             for species_id in list_of_species_ids:
-                network.setGeometricShape(species_id, 'ellipse')
+                network.setGeometricShapeType(species_id, 'ellipse')
                 self._check_set_dimensions_of_ellipse_geometric_shape(network, species_id)
 
     def test_set_dimensions_of_ellipse_geometric_shapes(self):
@@ -661,7 +663,7 @@ class TestSBMLNetwork(unittest.TestCase):
     def _check_move_rectangle_geometric_shape(self, network, entity_id):
         horizontal_displacement = 10.0
         vertical_displacement = 10.0
-        network.setGeometricShape(entity_id, 'rectangle')
+        network.setGeometricShapeType(entity_id, 'rectangle')
         # x
         geometric_shape_x = network.getGeometricShapeX(entity_id)
         network.setGeometricShapeX(entity_id, geometric_shape_x + horizontal_displacement)
@@ -674,7 +676,7 @@ class TestSBMLNetwork(unittest.TestCase):
     def _check_move_ellipse_geometric_shape(self, network, entity_id):
         center_x_displacement = 5.0
         center_y_displacement = 5.0
-        network.setGeometricShape(entity_id, 'ellipse')
+        network.setGeometricShapeType(entity_id, 'ellipse')
         # center x
         geometric_shape_center_x = network.getGeometricShapeCenterX(entity_id)
         network.setGeometricShapeCenterX(entity_id, geometric_shape_center_x + center_x_displacement)
@@ -687,7 +689,7 @@ class TestSBMLNetwork(unittest.TestCase):
     def _check_set_dimensions_of_rectangle_geometric_shape(self, network, entity_id):
         width_extension = 10.0
         height_extension = 10.0
-        network.setGeometricShape(entity_id, 'rectangle')
+        network.setGeometricShapeType(entity_id, 'rectangle')
         # width
         geometric_shape_width = network.getGeometricShapeWidth(entity_id)
         network.setGeometricShapeWidth(entity_id, geometric_shape_width + width_extension)
@@ -699,7 +701,7 @@ class TestSBMLNetwork(unittest.TestCase):
     def _check_set_dimensions_of_ellipse_geometric_shape(self, network, entity_id):
         radius_x_extension = 5.0
         radius_y_extension = 5.0
-        network.setGeometricShape(entity_id, 'ellipse')
+        network.setGeometricShapeType(entity_id, 'ellipse')
         # radius x
         geometric_shape_radius_x = network.getGeometricShapeRadiusX(entity_id)
         network.setGeometricShapeRadiusX(entity_id, geometric_shape_radius_x + radius_x_extension)

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -1796,32 +1796,44 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return -1;
     }
 
-    int c_api_setGeometricShape(SBMLDocument* document, const char* id, const char* shape, int graphicalObjectIndex, int layoutIndex) {
-        return setGeometricShape(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), shape);
+    const char* c_api_getGeometricShapeType(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return strdup(getGeometricShapeType(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex).c_str());
     }
 
-    int c_api_setCompartmentsGeometricShapes(SBMLDocument* document, const char* shape, int layoutIndex) {
-        return setCompartmentGeometricShape(document, layoutIndex, shape);
+    int c_api_setGeometricShapeType(SBMLDocument* document, const char* id, const char* shape, int graphicalObjectIndex, int layoutIndex) {
+        return setGeometricShapeType(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), shape);
     }
 
-    int c_api_setSpeciesGeometricShapes(SBMLDocument* document, const char* shape, int layoutIndex) {
-        return setSpeciesGeometricShape(document, layoutIndex, shape);
+    int c_api_setCompartmentsGeometricShapesType(SBMLDocument* document, const char* shape, int layoutIndex) {
+        return setCompartmentGeometricShapeType(document, layoutIndex, shape);
     }
 
-    int c_api_setReactionsGeometricShapes(SBMLDocument* document, const char* shape, int layoutIndex) {
-        return setReactionGeometricShape(document, layoutIndex, shape);
+    int c_api_setSpeciesGeometricShapesType(SBMLDocument* document, const char* shape, int layoutIndex) {
+        return setSpeciesGeometricShapeType(document, layoutIndex, shape);
     }
 
-    int c_api_setGeometricShapes(SBMLDocument* document, const char* shape, int layoutIndex) {
-        return setGeometricShape(document, layoutIndex, shape);
+    int c_api_setReactionsGeometricShapesType(SBMLDocument* document, const char* shape, int layoutIndex) {
+        return setReactionGeometricShapeType(document, layoutIndex, shape);
+    }
+
+    int c_api_setGeometricShapesType(SBMLDocument* document, const char* shape, int layoutIndex) {
+        return setGeometricShapeType(document, layoutIndex, shape);
     }
 
     bool c_api_isRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
         return isRectangle(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
     }
 
+    bool c_api_isSquare(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return isSquare(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
     bool c_api_isEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
         return isEllipse(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
+    bool c_api_isCircle(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return isCircle(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
     }
 
     bool c_api_isPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -3177,6 +3177,15 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_removeGeometricShape(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @breif Returns the type of the geometric shape of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex the index of the GraphicalObject to return.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return the type of the geometric shape of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL
+    LIBSBMLNETWORK_EXTERN const char* c_api_getGeometricShape(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
+
     /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
@@ -3185,7 +3194,6 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShape(SBMLDocument* document, const char* id, const char* shape, int graphicalObjectIndex = 0, int layoutIndex = 0);
-
 
     /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
@@ -3218,6 +3226,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// it is not of type Rectangle or is or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is of type Square.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square, @c false if
+    /// it is not of type Square or is or the object is @c NULL.
+    LIBSBMLNETWORK_EXTERN bool c_api_isSquare(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
+
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is of type Ellipse.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
@@ -3227,6 +3245,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Ellipse, @c false if
     /// it is not of type Ellipse or is or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
+
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is of type Circle.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle, @c false if
+    /// it is not of type Circle or is or the object is @c NULL.
+    LIBSBMLNETWORK_EXTERN bool c_api_isCircle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
     
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is of type Polygon.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -1840,24 +1840,24 @@ int addGeometricShape(Style* style, const std::string& shape) {
 
 int addGeometricShape(RenderGroup* renderGroup, const std::string& shape) {
     if (renderGroup) {
-        if (stringCompare(shape, "rectangle")) {
-            Rectangle* rectangle = renderGroup->createRectangle();
-            setDefaultRectangleShapeFeatures(rectangle);
-            return 0;
-        }
-        else if (stringCompare(shape, "square")) {
+        if (stringCompare(shape, "square")) {
             Rectangle* square = renderGroup->createRectangle();
             setDefaultSquareShapeFeatures(square);
             return 0;
         }
-        else if (stringCompare(shape, "ellipse")) {
-            Ellipse* ellipse = renderGroup->createEllipse();
-            setDefaultEllipseShapeFeatures(ellipse);
+        else if (stringCompare(shape, "rectangle")) {
+            Rectangle* rectangle = renderGroup->createRectangle();
+            setDefaultRectangleShapeFeatures(rectangle);
             return 0;
         }
         else if (stringCompare(shape, "circle")) {
             Ellipse* circle = renderGroup->createEllipse();
             setDefaultCircleShapeFeatures(circle);
+            return 0;
+        }
+        else if (stringCompare(shape, "ellipse")) {
+            Ellipse* ellipse = renderGroup->createEllipse();
+            setDefaultEllipseShapeFeatures(ellipse);
             return 0;
         }
         else if (stringCompare(shape, "triangle")) {
@@ -1936,14 +1936,14 @@ const std::string getGeometricShapeType(RenderGroup* renderGroup, unsigned int g
 }
 
 const std::string getGeometricShapeType(Transformation2D* shape) {
-    if (isRectangle(shape))
-        return "rectangle";
-    else if (isSquare(shape))
+    if (isSquare(shape))
         return "square";
-    else if (isEllipse(shape))
-        return "ellipse";
+    else if (isRectangle(shape))
+        return "rectangle";
     else if (isCircle(shape))
         return "circle";
+    else if (isEllipse(shape))
+        return "ellipse";
     else if (isPolygon(shape))
         return "polygon";
     else if (isRenderCurve(shape))

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -1845,9 +1845,19 @@ int addGeometricShape(RenderGroup* renderGroup, const std::string& shape) {
             setDefaultRectangleShapeFeatures(rectangle);
             return 0;
         }
+        else if (stringCompare(shape, "square")) {
+            Rectangle* square = renderGroup->createRectangle();
+            setDefaultSquareShapeFeatures(square);
+            return 0;
+        }
         else if (stringCompare(shape, "ellipse")) {
             Ellipse* ellipse = renderGroup->createEllipse();
             setDefaultEllipseShapeFeatures(ellipse);
+            return 0;
+        }
+        else if (stringCompare(shape, "circle")) {
+            Ellipse* circle = renderGroup->createEllipse();
+            setDefaultCircleShapeFeatures(circle);
             return 0;
         }
         else if (stringCompare(shape, "triangle")) {
@@ -1909,6 +1919,41 @@ Transformation2D* removeGeometricShape(RenderGroup* renderGroup, unsigned int ge
     return NULL;
 }
 
+const std::string getGeometricShapeType(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeType(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeType(Style* style, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getRenderGroup(style), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeType(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+const std::string getGeometricShapeType(Transformation2D* shape) {
+    if (isRectangle(shape))
+        return "rectangle";
+    else if (isSquare(shape))
+        return "square";
+    else if (isEllipse(shape))
+        return "ellipse";
+    else if (isCircle(shape))
+        return "circle";
+    else if (isPolygon(shape))
+        return "polygon";
+    else if (isRenderCurve(shape))
+        return "rendercurve";
+    else if (isImage(shape))
+        return "image";
+
+    return "";
+}
+
 int setGeometricShape(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& shape) {
     return setGeometricShape(getStyle(renderInformationBase, graphicalObject), shape);
 }
@@ -1955,6 +2000,29 @@ bool isRectangle(Transformation2D* shape) {
     return false;
 }
 
+bool isSquare(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isSquare(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+bool isSquare(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isSquare(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+bool isSquare(Style* style, unsigned int geometricShapeIndex) {
+    return isSquare(getRenderGroup(style), geometricShapeIndex);
+}
+
+bool isSquare(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return isSquare(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+bool isSquare(Transformation2D* shape) {
+    if (shape)
+        return isRectangle(shape) && ((Rectangle*)shape)->getRatio() == 1.0;
+
+    return false;
+}
+
 bool isEllipse(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
     return isEllipse(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
 }
@@ -1974,6 +2042,29 @@ bool isEllipse(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
 bool isEllipse(Transformation2D* shape) {
     if (shape)
         return shape->isEllipse();
+
+    return false;
+}
+
+bool isCircle(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isCircle(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+bool isCircle(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isCircle(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+bool isCircle(Style* style, unsigned int geometricShapeIndex) {
+    return isCircle(getRenderGroup(style), geometricShapeIndex);
+}
+
+bool isCircle(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return isCircle(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+bool isCircle(Transformation2D* shape) {
+    if (shape)
+        return isEllipse(shape) && ((Ellipse*)shape)->getRatio() == 1.0;
 
     return false;
 }

--- a/src/libsbmlnetwork_render.h
+++ b/src/libsbmlnetwork_render.h
@@ -2074,26 +2074,64 @@ LIBSBMLNETWORK_EXTERN Transformation2D* removeGeometricShape(RenderGroup* render
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int addGeometricShape(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& shape);
 
-/// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @brief Returns the geometric shape as a string based on the RenderInformationBase and GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an optional unsigned int representing the index of the Transformation2D to retrieve.
+/// @return A string representing the geometric shape, or an empty string if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Returns the geometric shape as a string based on the RenderInformationBase and a specific attribute.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
-/// @param shape a string value indicating the shape of the geometric shape to be added.
-/// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int setGeometricShape(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& shape);
+/// @param geometricShapeIndex an optional unsigned int representing the index of the Transformation2D to retrieve.
+/// @return A string representing the geometric shape, or an empty string if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex = 0);
 
-/// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of this Style object.
+/// @brief Returns the geometric shape as a string for a specific Style.
 /// @param style a pointer to the Style object.
-/// @param shape a string value indicating the shape of the geometric shape to be added.
+/// @param geometricShapeIndex an optional unsigned int representing the index of the Transformation2D to retrieve.
+/// @return A string representing the geometric shape, or an empty string if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(Style* style, unsigned int geometricShapeIndex = 0);
+
+/// @brief Returns the geometric shape as a string for a specific RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an optional unsigned int representing the index of the Transformation2D to retrieve.
+/// @return A string representing the geometric shape, or an empty string if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(RenderGroup* renderGroup, unsigned int geometricShapeIndex = 0);
+
+/// @brief Returns the geometric shape as a string for a specific Transformation2D object.
+/// @param shape a pointer to the Transformation2D object.
+/// @return A string representing the geometric shape, or an empty string if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(Transformation2D* shape);
+
+/// @brief Sets the geometric shape for a GraphicalObject based on RenderInformationBase.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param shape a string value indicating the shape of the geometric shape to be set.
+/// @return integer value indicating success/failure of the function.
+LIBSBMLNETWORK_EXTERN int setGeometricShape(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& shape);
+
+/// @brief Sets the geometric shape for a GraphicalObject based on its attribute.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param shape a string value indicating the shape of the geometric shape to be set.
+/// @return integer value indicating success/failure of the function.
+LIBSBMLNETWORK_EXTERN int setGeometricShape(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& shape);
+
+/// @brief Sets the geometric shape for a specific Style.
+/// @param style a pointer to the Style object.
+/// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int setGeometricShape(Style* style, const std::string& shape);
 
-/// @brief Sets the geometric shape as the single geometric shape of this RenderGroup.
+/// @brief Sets the geometric shape for a specific RenderGroup.
 /// @param renderGroup a pointer to the RenderGroup object.
-/// @param shape a string value indicating the shape of the geometric shape to be added.
+/// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int setGeometricShape(RenderGroup* renderGroup, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setGeometricShape(RenderGroup* renderGroup, const std::string& shape);
 
-/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Rectangle.
+/// @brief Checks if the Transformation2D at the given index of the RenderGroup of the Style for a GraphicalObject is of type Rectangle.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
@@ -2127,6 +2165,41 @@ LIBSBMLNETWORK_EXTERN bool isRectangle(RenderGroup* renderGroup, unsigned int ge
 /// @param shape a pointer to the Transformation2D object.
 /// @return @c true if this abstract Transformation2D is of type Rectangle, @c false if either it is not of type Rectangle or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isRectangle(Transformation2D* shape);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square, @c false if
+/// it is not of type Square or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is of type Square.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square, @c false if
+/// it is not of type Square or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of this Style is of type Square.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of this Style is of type Square, @c false if
+/// it is not of type Square or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(Style* style, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of this RenderGroup is of type Square.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of this RenderGroup is of type Square, @c false if
+/// it is not of type Square or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(RenderGroup* renderGroup, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if this abstract Transformation2D is of type Square.
+/// @param shape a pointer to the Transformation2D object.
+/// @return @c true if this abstract Transformation2D is of type Square, @c false if either it is not of type Square or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(Transformation2D* shape);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Ellipse.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.
@@ -2162,6 +2235,41 @@ LIBSBMLNETWORK_EXTERN bool isEllipse(RenderGroup* renderGroup, unsigned int geom
 /// @param shape a pointer to the Transformation2D object.
 /// @return @c true if this abstract Transformation2D is of type Ellipse, @c false if either it is not of type Ellipse or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isEllipse(Transformation2D* shape);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle, @c false if
+/// it is not of type Circle or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is of type Circle.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle, @c false if
+/// it is not of type Circle or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of this Style is of type Circle.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of this Style is of type Circle, @c false if
+/// it is not of type Circle or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(Style* style, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of this RenderGroup is of type Circle.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of this RenderGroup is of type Circle, @c false if
+/// it is not of type Circle or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(RenderGroup* renderGroup, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if this abstract Transformation2D is of type Circle.
+/// @param shape a pointer to the Transformation2D object.
+/// @return @c true if this abstract Transformation2D is of type Circle, @c false if either it is not of type Circle or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(Transformation2D* shape);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Polygon.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -454,7 +454,7 @@ Style* createLocalStyle(RenderInformationBase* localRenderInformation, Style* gl
 Style* createLocalStyle(RenderInformationBase* localRenderInformation, GraphicalObject* graphicalObject) {
     LocalStyle* localStyle = NULL;
     if (localRenderInformation && graphicalObject) {
-        localStyle = localRenderInformation->createLocalStyle();
+        localStyle = ((LocalRenderInformation*)localRenderInformation)->createLocalStyle();
         localStyle->addId(graphicalObject->getId());
         localStyle->setId(graphicalObject->getId() + "_style");
     }

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -445,14 +445,16 @@ void addLocalStyles(Layout* layout, LocalRenderInformation* localRenderInformati
 
 Style* createLocalStyle(RenderInformationBase* localRenderInformation, Style* globalStyle, GraphicalObject* graphicalObject) {
     Style* localStyle = createLocalStyle(localRenderInformation, graphicalObject);
-    localStyle->setGroup(globalStyle->getGroup()->clone());
+    if (localStyle && globalStyle)
+        localStyle->setGroup(globalStyle->getGroup()->clone());
+
     return localStyle;
 }
 
 Style* createLocalStyle(RenderInformationBase* localRenderInformation, GraphicalObject* graphicalObject) {
     LocalStyle* localStyle = NULL;
-    if (localRenderInformation->isLocalRenderInformation()) {
-        localStyle = ((LocalRenderInformation*)localRenderInformation)->createLocalStyle();
+    if (localRenderInformation && graphicalObject) {
+        localStyle = localRenderInformation->createLocalStyle();
         localStyle->addId(graphicalObject->getId());
         localStyle->setId(graphicalObject->getId() + "_style");
     }

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -627,6 +627,16 @@ void setDefaultRectangleShapeFeatures(Rectangle* rectangle) {
     rectangle->setRY(RelAbsVector(0.0, 10.0));
 }
 
+void setDefaultSquareShapeFeatures(Rectangle* square) {
+    setDefault2DShapeFeatures(square);
+    square->setX(RelAbsVector(0.0, 0.0));
+    square->setY(RelAbsVector(0.0, 0.0));
+    square->setWidth(RelAbsVector(0.0, 100.0));
+    square->setRatio(1.0);
+    square->setRX(RelAbsVector(0.0, 0.0));
+    square->setRY(RelAbsVector(0.0, 0.0));
+}
+
 void setDefaultEllipseShapeFeatures(Ellipse* ellipse) {
     setDefault2DShapeFeatures(ellipse);
     ellipse->setCX(RelAbsVector(0.0, 50.0));
@@ -635,6 +645,16 @@ void setDefaultEllipseShapeFeatures(Ellipse* ellipse) {
     ellipse->setRY(RelAbsVector(0.0, 50.0));
     ellipse->setStroke("black");
     ellipse->setStrokeWidth(2.0);
+}
+
+void setDefaultCircleShapeFeatures(Ellipse* circle) {
+    setDefault2DShapeFeatures(circle);
+    circle->setCX(RelAbsVector(0.0, 50.0));
+    circle->setCY(RelAbsVector(0.0, 50.0));
+    circle->setRX(RelAbsVector(0.0, 50.0));
+    circle->setRatio(1.0);
+    circle->setStroke("black");
+    circle->setStrokeWidth(2.0);
 }
 
 void setDefaultTriangleShapeFeatures(Polygon* triangle) {
@@ -1312,7 +1332,9 @@ std::vector<std::string> getValidFillRuleValues() {
 std::vector<std::string> getValidGeometricShapeNameValues() {
     std::vector <std::string> geometricShapeNames;
     geometricShapeNames.push_back("rectangle");
+    geometricShapeNames.push_back("square");
     geometricShapeNames.push_back("ellipse");
+    geometricShapeNames.push_back("circle");
     geometricShapeNames.push_back("triangle");
     geometricShapeNames.push_back("diamond");
     geometricShapeNames.push_back("pentagon");

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -163,7 +163,11 @@ void setDefault2DShapeFeatures(GraphicalPrimitive2D* graphicalPrimitive2D);
 
 void setDefaultRectangleShapeFeatures(Rectangle* rectangle);
 
+void setDefaultSquareShapeFeatures(Rectangle* square);
+
 void setDefaultEllipseShapeFeatures(Ellipse* ellipse);
+
+void setDefaultCircleShapeFeatures(Ellipse* circle);
 
 void setDefaultTriangleShapeFeatures(Polygon* triangle);
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -3233,7 +3233,15 @@ Transformation2D* removeGeometricShape(SBMLDocument* document, const std::string
     return removeGeometricShape(style, geometricShapeIndex);
 }
 
-int setGeometricShape(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& shape) {
+const std::string getGeometricShapeType(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getStyle(document, graphicalObject), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeType(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return getGeometricShapeType(getStyle(document, attribute), geometricShapeIndex);
+}
+
+int setGeometricShapeType(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& shape) {
     Style* style = getLocalStyle(document, graphicalObject);
     if (!style)
         style = createLocalStyle(document, graphicalObject);
@@ -3249,7 +3257,7 @@ int setGeometricShape(SBMLDocument* document, GraphicalObject* graphicalObject, 
     return -1;
 }
 
-int setGeometricShape(SBMLDocument* document, const std::string& attribute, const std::string& shape) {
+int setGeometricShapeType(SBMLDocument* document, const std::string& attribute, const std::string& shape) {
     Style* style = getLocalStyle(document, attribute);
     if (!style)
         style = createLocalStyle(document, attribute);
@@ -3265,42 +3273,42 @@ int setGeometricShape(SBMLDocument* document, const std::string& attribute, cons
     return -1;
 }
 
-int setCompartmentGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
+int setCompartmentGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
     Layout* layout = getLayout(document, layoutIndex);
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
-        if (setGeometricShape(document, layout->getCompartmentGlyph(i), shape))
+        if (setGeometricShapeType(document, layout->getCompartmentGlyph(i), shape))
             return -1;
     }
 
     return 0;
 }
 
-int setSpeciesGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
+int setSpeciesGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
     Layout* layout = getLayout(document, layoutIndex);
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
-        if (setGeometricShape(document, layout->getSpeciesGlyph(i), shape))
+        if (setGeometricShapeType(document, layout->getSpeciesGlyph(i), shape))
             return -1;
     }
 
     return 0;
 }
 
-int setReactionGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
+int setReactionGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
     Layout* layout = getLayout(document, layoutIndex);
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
-        if (setGeometricShape(document, layout->getReactionGlyph(i), shape))
+        if (setGeometricShapeType(document, layout->getReactionGlyph(i), shape))
             return -1;
     }
 
     return 0;
 }
 
-int setGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
-    if (setCompartmentGeometricShape(document, layoutIndex, shape))
+int setGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape) {
+    if (setCompartmentGeometricShapeType(document, layoutIndex, shape))
         return -1;
-    if (setSpeciesGeometricShape(document, layoutIndex, shape))
+    if (setSpeciesGeometricShapeType(document, layoutIndex, shape))
         return -1;
-    if (setReactionGeometricShape(document, layoutIndex, shape))
+    if (setReactionGeometricShapeType(document, layoutIndex, shape))
         return -1;
 
     return 0;
@@ -3314,12 +3322,28 @@ bool isRectangle(SBMLDocument* document, const std::string& attribute, unsigned 
     return isRectangle(getStyle(document, attribute), geometricShapeIndex);
 }
 
+bool isSquare(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isSquare(getStyle(document, graphicalObject), geometricShapeIndex);
+}
+
+bool isSquare(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isSquare(getStyle(document, attribute), geometricShapeIndex);
+}
+
 bool isEllipse(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
     return isEllipse(getStyle(document, graphicalObject), geometricShapeIndex);
 }
 
 bool isEllipse(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
     return isEllipse(getStyle(document, attribute), geometricShapeIndex);
+}
+
+bool isCircle(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isCircle(getStyle(document, graphicalObject), geometricShapeIndex);
+}
+
+bool isCircle(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isCircle(getStyle(document, attribute), geometricShapeIndex);
 }
 
 bool isPolygon(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -3663,47 +3663,61 @@ LIBSBMLNETWORK_EXTERN Transformation2D* removeGeometricShape(SBMLDocument* docum
 /// @return a pointer to the nth Transformation2D of the RenderGroup of the Style for this GraphicalObject, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN Transformation2D* removeGeometricShape(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the value the type of the geometric shape of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the type of the geometric shape of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Returns the value the type of the geometric shape of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the type of the geometric shape of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeType(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
+
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setGeometricShape(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeType(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& shape);
 
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setGeometricShape(SBMLDocument* document, const std::string& attribute, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeType(SBMLDocument* document, const std::string& attribute, const std::string& shape);
 
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style for all CompartmentGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setCompartmentGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setCompartmentGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
 
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style for for all SpeciesGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setSpeciesGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setSpeciesGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
 
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style for for all ReactionGlyph objects and their SpeciesReferenceGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setReactionGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setReactionGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
 
 /// @brief Sets the geometric shape as the single geometric shape of the RenderGroup of the Style for for all GraphicalObject objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
 /// @param shape a string value indicating the shape of the geometric shape to be set.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setGeometricShape(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeType(SBMLDocument* document, unsigned int layoutIndex, const std::string& shape);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Rectangle.
 /// @param document a pointer to the SBMLDocument object.
@@ -3721,6 +3735,22 @@ LIBSBMLNETWORK_EXTERN bool isRectangle(SBMLDocument* document, GraphicalObject* 
 /// it is not of type Rectangle or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isRectangle(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square, @c false if
+/// it is not of type Square or is or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is of type Square.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Square, @c false if
+/// it is not of type Square or is or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSquare(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
+
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Ellipse.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
@@ -3736,6 +3766,22 @@ LIBSBMLNETWORK_EXTERN bool isEllipse(SBMLDocument* document, GraphicalObject* gr
 /// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Ellipse, @c false if
 /// it is not of type Ellipse or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isEllipse(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle, @c false if
+/// it is not of type Circle or is or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex = 0);
+
+/// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is of type Circle.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Circle, @c false if
+/// it is not of type Circle or is or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isCircle(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is of type Polygon.
 /// @param document a pointer to the SBMLDocument object.


### PR DESCRIPTION
Now there is a check to see if the id belongs to an entity that has a graphical object. If so, then a local style is created