### PR TITLE
Make various functions more efficient.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ set_target_properties(libz PROPERTIES IMPORTED_LOCATION ${LIBZ_LIBRARY})
 
 ### shared library
 if (BUILD_SHARED_LIBS)
-	add_library(sbmlnetwork SHARED ${SOURCES})
+	add_library(sbmlnetwork SHARED ${SOURCES} ${HEADERS})
 	set_target_properties(sbmlnetwork PROPERTIES
 			VERSION ${LIBSBMLNETWORK_DOTTED_VERSION}
 			SOVERSION ${LIBSBMLNETWORK_VERSION_MAJOR})
@@ -73,7 +73,7 @@ endif ()
 
 ### static library
 if (BUILD_STATIC_LIBS)
-	add_library(sbmlnetwork-static STATIC ${SOURCES})
+	add_library(sbmlnetwork-static STATIC ${SOURCES} ${HEADERS})
 	target_link_libraries(sbmlnetwork-static ${LIBSBML_LIBRARY} ${EXTRA_LIBS})
 	target_include_directories(sbmlnetwork-static PUBLIC ${DEPENDENCIES_INCLUDE_DIR})
 	if (WIN32)

--- a/src/autolayout/libsbmlnetwork_autolayout_node.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout_node.cpp
@@ -97,7 +97,7 @@ void AutoLayoutNode::updateDimensions() {
 }
 
 const double AutoLayoutNode::getX() {
-    return roundToTwoDecimalPlaces(_graphicalObject->getBoundingBox()->x());
+    return _graphicalObject->getBoundingBox()->x();
 }
 
 void AutoLayoutNode::setX(const double& x) {
@@ -106,7 +106,7 @@ void AutoLayoutNode::setX(const double& x) {
 }
 
 const double AutoLayoutNode::getY() {
-    return roundToTwoDecimalPlaces(_graphicalObject->getBoundingBox()->y());
+    return _graphicalObject->getBoundingBox()->y();
 }
 
 void AutoLayoutNode::setY(const double& y) {
@@ -187,7 +187,8 @@ void AutoLayoutCentroidNode::updateDimensions() {
 }
 
 const double AutoLayoutCentroidNode::getX() {
-    return roundToTwoDecimalPlaces(0.5 * (getCurve()->getCurveSegment(0)->getStart()->x() + getCurve()->getCurveSegment(0)->getEnd()->x()));
+    const LineSegment* ls = getCurve()->getCurveSegment(0);
+    return 0.5 * (ls->getStart()->x() + ls->getEnd()->x());
 }
 
 void AutoLayoutCentroidNode::setX(const double& x) {
@@ -200,7 +201,8 @@ void AutoLayoutCentroidNode::setX(const double& x) {
 }
 
 const double AutoLayoutCentroidNode::getY() {
-    return roundToTwoDecimalPlaces(0.5 * (getCurve()->getCurveSegment(0)->getStart()->y() + getCurve()->getCurveSegment(0)->getEnd()->y()));
+    const LineSegment* ls = getCurve()->getCurveSegment(0);
+    return 0.5 * (ls->getStart()->y() + ls->getEnd()->y());
 }
 
 void AutoLayoutCentroidNode::setY(const double& y) {
@@ -213,7 +215,8 @@ void AutoLayoutCentroidNode::setY(const double& y) {
 }
 
 const double AutoLayoutCentroidNode::getWidth() {
-    return roundToTwoDecimalPlaces(getCurve()->getCurveSegment(0)->getEnd()->x() - getCurve()->getCurveSegment(0)->getStart()->x());
+    LineSegment* ls = getCurve()->getCurveSegment(0);
+    return ls->getEnd()->x() - ls->getStart()->x();
 }
 
 const double AutoLayoutCentroidNode::getDefaultWidth() {
@@ -236,7 +239,8 @@ void AutoLayoutCentroidNode::setBoundingBoxWidth(const double& width) {
 }
 
 const double AutoLayoutCentroidNode::getHeight() {
-    return roundToTwoDecimalPlaces(getCurve()->getCurveSegment(0)->getEnd()->y() - getCurve()->getCurveSegment(0)->getStart()->y());
+    LineSegment* ls = getCurve()->getCurveSegment(0);
+    return ls->getEnd()->y() - ls->getStart()->y();
 }
 
 const double AutoLayoutCentroidNode::getDefaultHeight() {

--- a/src/autolayout/libsbmlnetwork_autolayout_node.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout_node.cpp
@@ -128,7 +128,7 @@ void AutoLayoutNode::setWidth(const double& width) {
 }
 
 const double AutoLayoutNode::getHeight() {
-    return roundToTwoDecimalPlaces(_graphicalObject->getBoundingBox()->height());
+    return _graphicalObject->getBoundingBox()->height();
 }
 
 const double AutoLayoutNode::getDefaultHeight() {

--- a/src/autolayout/libsbmlnetwork_autolayout_node.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout_node.cpp
@@ -115,7 +115,7 @@ void AutoLayoutNode::setY(const double& y) {
 }
 
 const double AutoLayoutNode::getWidth() {
-    return roundToTwoDecimalPlaces(_graphicalObject->getBoundingBox()->width());
+    return _graphicalObject->getBoundingBox()->width();
 }
 
 const double AutoLayoutNode::getDefaultWidth() {
@@ -215,7 +215,7 @@ void AutoLayoutCentroidNode::setY(const double& y) {
 }
 
 const double AutoLayoutCentroidNode::getWidth() {
-    LineSegment* ls = getCurve()->getCurveSegment(0);
+    const LineSegment* ls = getCurve()->getCurveSegment(0);
     return ls->getEnd()->x() - ls->getStart()->x();
 }
 
@@ -239,7 +239,7 @@ void AutoLayoutCentroidNode::setBoundingBoxWidth(const double& width) {
 }
 
 const double AutoLayoutCentroidNode::getHeight() {
-    LineSegment* ls = getCurve()->getCurveSegment(0);
+    const LineSegment* ls = getCurve()->getCurveSegment(0);
     return ls->getEnd()->y() - ls->getStart()->y();
 }
 

--- a/src/autolayout/libsbmlnetwork_autolayout_point.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout_point.cpp
@@ -9,7 +9,7 @@ AutoLayoutPoint::AutoLayoutPoint(const double& x, const double& y) {
 }
 
 const double AutoLayoutPoint::getX() const {
-    return roundToTwoDecimalPlaces(_x);
+    return _x;
 };
 
 void AutoLayoutPoint::setX(const double& x) {
@@ -17,7 +17,7 @@ void AutoLayoutPoint::setX(const double& x) {
 }
 
 const double AutoLayoutPoint::getY() const {
-    return roundToTwoDecimalPlaces(_y);
+    return _y;
 };
 
 void AutoLayoutPoint::setY(const double& y) {

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -9601,48 +9601,40 @@ class LibSBMLNetwork:
 
         return list_of_distribution_directions
 
-    def getListOfColorNames(self):
+    def getPredefinedColorNames(self):
         """
-        Returns the list of valid html color names that can be used as the value of colors in the SBML Document
+        Returns the list of predefined html color names that can be used as the value of colors in the SBML Document
 
         :Returns:
 
-            a list of strings that determines the valid html color names that can be used as the value of colors in the SBML Document
+            a list of strings that determines the predefined html color names that can be used as the value of colors in the SBML Document
 
         """
-        lib.c_api_getNthValidColorNameValue.restype = ctypes.c_char_p
-        list_of_color_names = []
-        for n in range(lib.c_api_getNumValidColorNameValues()):
-            list_of_color_names.append(ctypes.c_char_p(lib.c_api_getNthValidColorNameValue(n)).value.decode())
+        colors = lib.colorData()
+        return colors.keys()
 
-        return list_of_color_names
-
-    def getListOfHexColorCodes(self):
+    def getPredefinedHexColorCodes(self):
         """
-        Returns the list of valid hex color codes that can be used as the value of colors in the SBML Document
+        Returns the list of predefined hex color codes that can be used as the value of colors in the SBML Document
 
         :Returns:
 
-            a list of strings that determines the valid hex color codes that can be used as the value of colors in the SBML Document
+            a list of strings that determines the predefined hex color codes that can be used as the value of colors in the SBML Document
 
         """
-        lib.c_api_getNthValidHexColorCodeValue.restype = ctypes.c_char_p
-        list_of_hex_color_codes = []
-        for n in range(lib.c_api_getNumValidHexColorCodeValues()):
-            list_of_hex_color_codes.append(ctypes.c_char_p(lib.c_api_getNthValidHexColorCodeValue(n)).value.decode())
+        colors = lib.colorData()
+        return colors.values()
 
-        return list_of_hex_color_codes
-
-    def getListOfColors(self):
+    def getPredefinedColors(self):
         """
-        Returns the list of all valid colors that can be used as the value of colors in the SBML Document
+        Returns the dictionary of all predefined color names and the hex values they correspond to that can be used as the value of colors in the SBML Document
 
         :Returns:
 
-            a list of strings that determines the valid colors that can be used as the value of colors in the SBML Document
+            a dictionary of predefined color name strings that can be used as the value of colors in the SBML Document
 
         """
-        return self.getListOfColorNames() + self.getListOfHexColorCodes()
+        return lib.colorData()
 
     def getListOfSpreadMethods(self):
         """

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -2674,28 +2674,6 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return "";
     }
 
-    int c_api_getNumValidColorNameValues() {
-        return getValidHtmlColorNames().size();
-    }
-
-    const char* c_api_getNthValidColorNameValue(int index) {
-        if (index >= 0 && index < c_api_getNumValidColorNameValues())
-            return strdup(getValidHtmlColorNames().at(index).c_str());
-
-        return "";
-    }
-
-    int c_api_getNumValidHexColorCodeValues() {
-        return getValidHexColorCodes().size();
-    }
-
-    const char* c_api_getNthValidHexColorCodeValue(int index) {
-        if (index >= 0 && index < c_api_getNumValidHexColorCodeValues())
-            return strdup(getValidHexColorCodes().at(index).c_str());
-
-        return "";
-    }
-
     int c_api_getNumValidSpreadMethodValues() {
         return getValidSpreadMethodValues().size();
     }

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -4656,22 +4656,6 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param index an int representing the index of the valid value to retrieve.
     LIBSBMLNETWORK_EXTERN const char* c_api_getNthValidDistributionDirectionValue(int index);
 
-    /// @brief Returns the number of valid values for the "color" name attribute that can be used in for all set color value functions.
-    /// @return the number of valid values for the "color" name attribute.
-    LIBSBMLNETWORK_EXTERN int c_api_getNumValidColorNameValues();
-
-    /// @brief Returns the nth valid value for the "color" name attribute that can be used in for all set color value functions.
-    /// @param index an int representing the index of the valid value to retrieve.
-    LIBSBMLNETWORK_EXTERN const char* c_api_getNthValidColorNameValue(int index);
-
-    /// @brief Returns the number of valid values for the hex "color" attribute that can be used in for all set color value functions.
-    /// @return the number of valid values for the hex "color" attribute.
-    LIBSBMLNETWORK_EXTERN int c_api_getNumValidHexColorCodeValues();
-
-    /// @brief Returns the nth valid value for the hex "color" attribute that can be used in for all set color value functions.
-    /// @param index an int representing the index of the valid value to retrieve.
-    LIBSBMLNETWORK_EXTERN const char* c_api_getNthValidHexColorCodeValue(int index);
-
     /// @brief Returns the number of valid values for the "spread-method" attribute that can be used in for c_api_setGradientSpreadMethod function.
     /// @return the number of valid values for the "spread-method" attribute.
     LIBSBMLNETWORK_EXTERN int c_api_getNumValidSpreadMethodValues();

--- a/src/colors/libsbmlnetwork_colors.cpp
+++ b/src/colors/libsbmlnetwork_colors.cpp
@@ -242,7 +242,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         if (color == colors->end()) {
             return "";
         }
-        return color->first;
+        return color->second;
     }
 
     const std::string getHtmlColorNameFromHexColorCode(const std::string& hexColorCode) {

--- a/src/colors/libsbmlnetwork_colors.cpp
+++ b/src/colors/libsbmlnetwork_colors.cpp
@@ -4,8 +4,8 @@
 
 namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
-    std::vector<std::pair<std::string, std::string>> colorData() {
-        static std::vector<std::pair<std::string, std::string>> colors = {
+    const std::map<std::string, std::string>* colorData() {
+        static std::map<std::string, std::string> colors = {
                 {"aliceblue", "#F0F8FF"},
                 {"antiquewhite", "#FAEBD7"},
                 {"aqua", "#00FFFF"},
@@ -233,28 +233,25 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
                 {"yellow", "#FFFF00"},
                 {"yellowgreen", "#9ACD32"}};
 
-        return colors;
+        return &colors;
     }
 
     const std::string getHexColorCodeFromHtmlColorName(const std::string& htmlColorName) {
-        std::vector <std::string> htmlColorNames = getValidHtmlColorNames();
-        std::vector <std::string> hexColorCodes = getValidHexColorCodes();
-        for (unsigned int i = 0; i < htmlColorNames.size(); i++) {
-            if (stringCompare(htmlColorNames.at(i), htmlColorName))
-                return hexColorCodes.at(i);
+        const std::map<std::string, std::string>* colors = colorData();
+        auto color = colors->find(htmlColorName.c_str());
+        if (color == colors->end()) {
+            return "";
         }
-
-        return "";
+        return color->first;
     }
 
     const std::string getHtmlColorNameFromHexColorCode(const std::string& hexColorCode) {
-        std::vector <std::string> hexColorCodes = getValidHexColorCodes();
-        std::vector <std::string> htmlColorNames = getValidHtmlColorNames();
-        for (unsigned int i = 0; i < hexColorCodes.size(); i++) {
-            if (stringCompare(hexColorCodes.at(i), hexColorCode))
-                return htmlColorNames.at(i);
+        const std::map<std::string, std::string>* colors = colorData();
+        for (auto color = colors->begin(); color != colors->end(); color++) {
+            if (stringCompare(color->second, hexColorCode)) {
+                return color->first;
+            }
         }
-
         return "";
     }
 
@@ -275,35 +272,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     const bool isValidColorValue(const std::string& value) {
-        std::vector<std::string> htmlColorNames = getValidHtmlColorNames();
-        for (unsigned int i = 0; i < htmlColorNames.size(); i++) {
-            if (stringCompare(htmlColorNames.at(i), value))
-                return true;
+        const std::map<std::string, std::string>* colors = colorData();
+        if (colors->find(value.c_str()) != colors->end()) {
+            return true;
         }
-        std::vector<std::string> hexColorCodes = getValidHexColorCodes();
-        for (unsigned int i = 0; i < hexColorCodes.size(); i++) {
-            if (stringCompare(hexColorCodes.at(i), value))
-                return true;
-        }
-
         return isValidHexColorCode(value);
     }
 
-    std::vector<std::string> getValidHtmlColorNames() {
-        std::vector<std::string> htmlColorNames;
-        for (unsigned int i = 0; i < colorData().size(); i++) {
-            htmlColorNames.push_back(colorData().at(i).first);
-        }
-
-        return htmlColorNames;
-    }
-
-    std::vector<std::string> getValidHexColorCodes() {
-        std::vector<std::string> hexColorCodes;
-        for (unsigned int i = 0; i < colorData().size(); i++) {
-            hexColorCodes.push_back(colorData().at(i).second);
-        }
-
-        return hexColorCodes;
-    }
 }

--- a/src/colors/libsbmlnetwork_colors.h
+++ b/src/colors/libsbmlnetwork_colors.h
@@ -4,10 +4,11 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
-    std::vector<std::pair<std::string, std::string>> colorData();
+    const std::map<std::string, std::string>* colorData();
 
     const std::string getHexColorCodeFromHtmlColorName(const std::string& htmlColorName);
 
@@ -18,10 +19,6 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     const bool isxdigit(const char& c);
 
     const bool isValidColorValue(const std::string& value);
-
-    std::vector<std::string> getValidHtmlColorNames();
-
-    std::vector<std::string> getValidHexColorCodes();
 }
 
 #endif

--- a/src/libsbmlnetwork_layout_helpers.cpp
+++ b/src/libsbmlnetwork_layout_helpers.cpp
@@ -1,6 +1,7 @@
 #include "libsbmlnetwork_layout_helpers.h"
 #include "libsbmlnetwork_common.h"
 #include "libsbmlnetwork_layout.h"
+#include "libsbmlnetwork_sbmldocument_layout.h"
 
 #include <cmath>
 #include <climits>
@@ -59,8 +60,21 @@ void enableLayoutPlugin(SBMLDocument* document) {
     document->setPackageRequired("layout", false);
 }
 
+void freeUserData(SBMLDocument* document) {
+    if (document) {
+        const int numLayouts = getNumLayouts(document);
+        for (int i = 0; i < numLayouts; i++)
+            freeUserData(getLayout(document, i));
+    }
+}
+
 void freeUserData(Layout* layout) {
-    freeUserData(layout);
+    if (layout->isSetUserData()) {
+        auto userData = (std::map<std::string, std::string>*)layout->getUserData();
+        if (userData) {
+            delete userData;
+        }
+    }
     freeUserData(layout->getDimensions());
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++)
         freeUserData(layout->getCompartmentGlyph(i));
@@ -129,10 +143,6 @@ void setDefaultLayoutId(Layout* layout) {
 
 const std::string getDefaultLayoutId() {
     return  "libSBMLNetwork_Layout";
-}
-
-const bool canUpdateLayoutCurves(Layout* layout) {
-    return layout->getId() == getDefaultLayoutId();
 }
 
 void setDefaultLayoutDimensions(Layout* layout) {

--- a/src/libsbmlnetwork_layout_helpers.h
+++ b/src/libsbmlnetwork_layout_helpers.h
@@ -22,6 +22,8 @@ LayoutModelPlugin* getLayoutModelPlugin(SBasePlugin* layoutBase);
 
 void enableLayoutPlugin(SBMLDocument* document);
 
+void freeUserData(SBMLDocument* document);
+
 void freeUserData(Layout* layout);
 
 void freeUserData(SBase* sbase);
@@ -35,8 +37,6 @@ void setUserData(SBase* sBase, const std::string& key, const std::string& value)
 void setDefaultLayoutId(Layout* layout);
 
 const std::string getDefaultLayoutId();
-
-const bool canUpdateLayoutCurves(Layout* layout);
 
 void setDefaultLayoutDimensions(Layout* layout);
 

--- a/src/libsbmlnetwork_sbmldocument.cpp
+++ b/src/libsbmlnetwork_sbmldocument.cpp
@@ -48,9 +48,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
 
     bool freeSBMLDocument(SBMLDocument* document) {
         if (document) {
-            const int numLayouts = getNumLayouts(document);
-            for (int i = 0; i < numLayouts; i++)
-                freeUserData(getLayout(document, i));
+            freeUserData(document);
             delete document;
             return true;
         }

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -864,10 +864,10 @@ const double getPositionX(SBMLDocument* document, unsigned int layoutIndex, cons
     return getPositionX(getLayout(document, layoutIndex), id, graphicalObjectIndex);
 }
 
-int setPositionX(SBMLDocument* document, const std::string& id, const double& x) {
+int setPositionX(SBMLDocument* document, const std::string& id, const double& x, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPositionX(layout, id, x)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -875,10 +875,10 @@ int setPositionX(SBMLDocument* document, const std::string& id, const double& x)
     return -1;
 }
 
-int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x) {
+int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPositionX(layout, id, x)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -886,10 +886,10 @@ int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::st
     return -1;
 }
 
-int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x) {
+int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPositionX(layout, id, graphicalObjectIndex, x)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -897,10 +897,10 @@ int setPositionX(SBMLDocument* document, const std::string& id, unsigned int gra
     return -1;
 }
 
-int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x) {
+int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPositionX(layout, id, graphicalObjectIndex, x)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -916,10 +916,10 @@ const double getPositionY(SBMLDocument* document, unsigned int layoutIndex, cons
     return getPositionY(getLayout(document, layoutIndex), id, graphicalObjectIndex);
 }
 
-int setPositionY(SBMLDocument* document, const std::string& id, const double& y) {
+int setPositionY(SBMLDocument* document, const std::string& id, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPositionY(layout, id, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -927,10 +927,10 @@ int setPositionY(SBMLDocument* document, const std::string& id, const double& y)
     return -1;
 }
 
-int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y) {
+int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPositionY(layout, id, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -938,10 +938,10 @@ int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::st
     return -1;
 }
 
-int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y) {
+int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPositionY(layout, id, graphicalObjectIndex, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -949,10 +949,10 @@ int setPositionY(SBMLDocument* document, const std::string& id, unsigned int gra
     return -1;
 }
 
-int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y) {
+int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPositionY(layout, id, graphicalObjectIndex, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -960,10 +960,10 @@ int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::st
     return -1;
 }
 
-int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y) {
+int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPosition(layout, id, x, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -971,10 +971,10 @@ int setPosition(SBMLDocument* document, const std::string& id, const double& x, 
     return -1;
 }
 
-int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y) {
+int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPosition(layout, id, x, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -982,10 +982,10 @@ int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::str
     return -1;
 }
 
-int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y) {
+int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setPosition(layout, id, graphicalObjectIndex, x, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -993,10 +993,10 @@ int setPosition(SBMLDocument* document, const std::string& id, unsigned int grap
     return -1;
 }
 
-int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y) {
+int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setPosition(layout, id, graphicalObjectIndex, x, y)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1012,10 +1012,10 @@ const double getDimensionWidth(SBMLDocument* document, unsigned int layoutIndex,
     return getDimensionWidth(getLayout(document, layoutIndex), id, graphicalObjectIndex);
 }
 
-int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width) {
+int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setDimensionWidth(layout, id, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1023,10 +1023,10 @@ int setDimensionWidth(SBMLDocument* document, const std::string& id, const doubl
     return -1;
 }
 
-int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width) {
+int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setDimensionWidth(layout, id, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1034,10 +1034,10 @@ int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const st
     return -1;
 }
 
-int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width) {
+int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setDimensionWidth(layout, id, graphicalObjectIndex, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1045,10 +1045,10 @@ int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned in
     return -1;
 }
 
-int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width) {
+int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setDimensionWidth(layout, id, graphicalObjectIndex, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1056,10 +1056,10 @@ int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const st
     return -1;
 }
 
-int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width) {
+int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setCompartmentDimensionWidth(layout, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1072,10 +1072,10 @@ const double getSpeciesDimensionWidth() {
 }
 
 
-int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width) {
+int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setSpeciesDimensionWidth(layout, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1087,10 +1087,10 @@ const double getReactionDimensionWidth() {
     return getReactionDefaultWidth();
 }
 
-int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width) {
+int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setReactionDimensionWidth(layout, width)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1106,10 +1106,10 @@ const double getDimensionHeight(SBMLDocument* document, unsigned int layoutIndex
     return getDimensionHeight(getLayout(document, layoutIndex), id, graphicalObjectIndex);
 }
 
-int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height) {
+int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setDimensionHeight(layout, id, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1117,10 +1117,10 @@ int setDimensionHeight(SBMLDocument* document, const std::string& id, const doub
     return -1;
 }
 
-int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height) {
+int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setDimensionHeight(layout, id, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1128,10 +1128,10 @@ int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const s
     return -1;
 }
 
-int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height) {
+int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document);
     if (!setDimensionHeight(layout, id, graphicalObjectIndex, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1139,10 +1139,10 @@ int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned i
     return -1;
 }
 
-int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height) {
+int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setDimensionHeight(layout, id, graphicalObjectIndex, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1150,10 +1150,10 @@ int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const s
     return -1;
 }
 
-int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height) {
+int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setCompartmentDimensionHeight(layout, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1165,10 +1165,10 @@ const double getSpeciesDimensionHeight() {
     return getSpeciesDefaultHeight();
 }
 
-int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height) {
+int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setSpeciesDimensionHeight(layout, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }
@@ -1180,10 +1180,10 @@ const double getReactionDimensionHeight() {
     return getReactionDefaultHeight();
 }
 
-int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height) {
+int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves) {
     Layout* layout = getLayout(document, layoutIndex);
     if (!setReactionDimensionHeight(layout, height)) {
-        if (canUpdateLayoutCurves(layout))
+        if (updateCurves)
             updateLayoutCurves(document, layout);
         return 0;
     }

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -1748,9 +1748,9 @@ LIBSBMLNETWORK_EXTERN const double getPositionX(SBMLDocument* document, unsigned
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, const double& x, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, const double& x, bool updateCurves = true);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1758,9 +1758,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, bool updateCurves = true);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1768,9 +1768,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layo
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = true);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1779,9 +1779,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = true);
 
 /// @brief Returns the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1805,9 +1805,9 @@ LIBSBMLNETWORK_EXTERN const double getPositionY(SBMLDocument* document, unsigned
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, const double& y, bool updateCurves = true);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1815,9 +1815,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y, bool updateCurves = true);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1825,9 +1825,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layo
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = true);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1836,9 +1836,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = true);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1846,9 +1846,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layo
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y, bool updateCurves = true);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1857,9 +1857,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string&
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y, bool updateCurves = true);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1869,9 +1869,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layou
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = true);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1881,9 +1881,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string&
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = true);
 
 /// @brief Returns the value of the "width" attribute of the bounding box of the bounding box of the GraphicalObject with the given index associated with
 /// the model entity with the given id of the first Layout object in the SBML document.
@@ -1907,9 +1907,9 @@ LIBSBMLNETWORK_EXTERN const double getDimensionWidth(SBMLDocument* document, uns
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width, bool updateCurves = true);
 
 /// @brief Sets the value of the "width" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1917,9 +1917,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::s
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width, bool updateCurves = true);
 
 /// @brief Sets the value of the "width" attribute of the bounding box the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1927,9 +1927,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = true);
 
 /// @brief Sets the value of the "width" attribute of the bounding box the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1938,17 +1938,17 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::s
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = true);
 
 /// @brief Sets the value of the "width" attribute the bounding box of all the CompartmentGlyph objects in the Layout object with the given index in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the CompartmentGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = true);
 
 /// @brief Returns the default value of the "width" attribute of the bounding box of the SpeciesGlyph objects.
 /// @return the default "width" attribute of the bounding box of the SpeciesGlyph objects.
@@ -1958,9 +1958,9 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesDimensionWidth();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the SpeciesGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = true);
 
 /// @brief Returns the default value of the "width" attribute of the bounding box of the ReactionGlyph objects.
 /// @return the default "width" attribute of the bounding box of the ReactionGlyph objects.
@@ -1970,9 +1970,9 @@ LIBSBMLNETWORK_EXTERN const double getReactionDimensionWidth();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the ReactionGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = true);
 
 /// @brief Returns the value of the "height" attribute of the bounding box of the bounding box of the GraphicalObject with the given index associated with
 /// the model entity with the given id of the first Layout object in the SBML document.
@@ -1996,9 +1996,9 @@ LIBSBMLNETWORK_EXTERN const double getDimensionHeight(SBMLDocument* document, un
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height, bool updateCurves = true);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the bounding box of the first GraphicalObject associated with
 /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -2006,9 +2006,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height, bool updateCurves = true);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the GraphicalObject object with the given index of associated with
 /// the object with the given id of the first Layout object in the SBML document.
@@ -2016,9 +2016,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned in
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = true);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the GraphicalObject object with the given index of associated with
 /// the object with the given id of the Layout object with the given index in the SBML document.
@@ -2027,17 +2027,17 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = true);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of all the CompartmentGlyph objects in the Layout object with the given index in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the CompartmentGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = true);
 
 /// @brief Returns the default value of the "height" attribute of the bounding box of the SpeciesGlyph objects.
 /// @return the default "height" attribute of the bounding box of the SpeciesGlyph objects.
@@ -2047,9 +2047,9 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesDimensionHeight();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the SpeciesGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = true);
 
 /// @brief Returns the default value of the "height" attribute of the bounding box of the ReactionGlyph objects.
 /// @return the default "height" attribute of the bounding box of the ReactionGlyph objects.
@@ -2059,9 +2059,9 @@ LIBSBMLNETWORK_EXTERN const double getReactionDimensionHeight();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the ReactionGlyph objects.
-/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'true'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
+LIBSBMLNETWORK_EXTERN int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = true);
 
 /// @brief Retrieves the "x" position of a TextGlyph object within a specific layout.
 /// This function fetches the "x" coordinate of the bounding box of a TextGlyph object, identified by its associated model entity ID and within a specified layout of the SBML document. The layout is determined by its index. Defaults for graphicalObjectIndex and textGlyphIndex are 0. If the TextGlyph object or the layout does not exist, the function returns 0.0.

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -1748,8 +1748,9 @@ LIBSBMLNETWORK_EXTERN const double getPositionX(SBMLDocument* document, unsigned
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, const double& x);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, const double& x, bool updateCurves = false);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1757,8 +1758,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, bool updateCurves = false);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1766,8 +1768,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layo
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = false);
 
 /// @brief Sets the value of the "x" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1776,8 +1779,9 @@ LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, const std::string
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setPositionX(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, bool updateCurves = false);
 
 /// @brief Returns the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1801,8 +1805,9 @@ LIBSBMLNETWORK_EXTERN const double getPositionY(SBMLDocument* document, unsigned
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, const double& y);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, const double& y, bool updateCurves = false);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1810,8 +1815,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& y, bool updateCurves = false);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1819,8 +1825,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layo
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = false);
 
 /// @brief Sets the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1829,8 +1836,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, const std::string
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& y, bool updateCurves = false);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1838,8 +1846,9 @@ LIBSBMLNETWORK_EXTERN int setPositionY(SBMLDocument* document, unsigned int layo
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, const double& x, const double& y, bool updateCurves = false);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1848,8 +1857,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string&
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& x, const double& y, bool updateCurves = false);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1859,8 +1869,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layou
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = false);
 
 /// @breif Sets th value of the "x" and "y" attributes of the bounding box of the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1870,8 +1881,9 @@ LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, const std::string&
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param x a double value to use as the value of the "x" attribute of the bounding box of this GraphicalObject object.
 /// @param y a double value to use as the value of the "y" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y);
+LIBSBMLNETWORK_EXTERN int setPosition(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& x, const double& y, bool updateCurves = false);
 
 /// @brief Returns the value of the "width" attribute of the bounding box of the bounding box of the GraphicalObject with the given index associated with
 /// the model entity with the given id of the first Layout object in the SBML document.
@@ -1895,8 +1907,9 @@ LIBSBMLNETWORK_EXTERN const double getDimensionWidth(SBMLDocument* document, uns
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, const double& width, bool updateCurves = false);
 
 /// @brief Sets the value of the "width" attribute of the bounding box of the first GraphicalObject associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1904,8 +1917,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::s
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& width, bool updateCurves = false);
 
 /// @brief Sets the value of the "width" attribute of the bounding box the GraphicalObject with the given index associated with the model entity with
 /// the given id of the first Layout object in the SBML document.
@@ -1913,8 +1927,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = false);
 
 /// @brief Sets the value of the "width" attribute of the bounding box the GraphicalObject with the given index associated with the model entity with
 /// the given id of the Layout object with the given index in the SBML document.
@@ -1923,15 +1938,17 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, const std::s
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& width, bool updateCurves = false);
 
 /// @brief Sets the value of the "width" attribute the bounding box of all the CompartmentGlyph objects in the Layout object with the given index in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the CompartmentGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setCompartmentDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
 
 /// @brief Returns the default value of the "width" attribute of the bounding box of the SpeciesGlyph objects.
 /// @return the default "width" attribute of the bounding box of the SpeciesGlyph objects.
@@ -1941,8 +1958,9 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesDimensionWidth();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the SpeciesGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setSpeciesDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
 
 /// @brief Returns the default value of the "width" attribute of the bounding box of the ReactionGlyph objects.
 /// @return the default "width" attribute of the bounding box of the ReactionGlyph objects.
@@ -1952,8 +1970,9 @@ LIBSBMLNETWORK_EXTERN const double getReactionDimensionWidth();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param width a double value to use as the value of the "width" attribute of the bounding box of all the ReactionGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setReactionDimensionWidth(SBMLDocument* document, unsigned int layoutIndex, const double& width, bool updateCurves = false);
 
 /// @brief Returns the value of the "height" attribute of the bounding box of the bounding box of the GraphicalObject with the given index associated with
 /// the model entity with the given id of the first Layout object in the SBML document.
@@ -1977,8 +1996,9 @@ LIBSBMLNETWORK_EXTERN const double getDimensionHeight(SBMLDocument* document, un
 /// @param document a pointer to the SBMLDocument object.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, const double& height, bool updateCurves = false);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the bounding box of the first GraphicalObject associated with
 /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -1986,8 +2006,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::
 /// @param layoutIndex the index number of the Layout to return.
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, const double& height, bool updateCurves = false);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the GraphicalObject object with the given index of associated with
 /// the object with the given id of the first Layout object in the SBML document.
@@ -1995,8 +2016,9 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned in
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = false);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of the GraphicalObject object with the given index of associated with
 /// the object with the given id of the Layout object with the given index in the SBML document.
@@ -2005,15 +2027,17 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, const std::
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of this GraphicalObject object.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, const double& height, bool updateCurves = false);
 
 /// @brief Sets the value of the "height" attribute of the bounding box of all the CompartmentGlyph objects in the Layout object with the given index in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the CompartmentGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setCompartmentDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
 
 /// @brief Returns the default value of the "height" attribute of the bounding box of the SpeciesGlyph objects.
 /// @return the default "height" attribute of the bounding box of the SpeciesGlyph objects.
@@ -2023,8 +2047,9 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesDimensionHeight();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the SpeciesGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setSpeciesDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
 
 /// @brief Returns the default value of the "height" attribute of the bounding box of the ReactionGlyph objects.
 /// @return the default "height" attribute of the bounding box of the ReactionGlyph objects.
@@ -2034,8 +2059,9 @@ LIBSBMLNETWORK_EXTERN const double getReactionDimensionHeight();
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.
 /// @param height a double value to use as the value of the "height" attribute of the bounding box of all the ReactionGlyph objects.
+/// @param updateCurves a boolean value, indicating whether the rest of the layout curves (with locked nodes) should be adjusted.  Default 'false'.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setReactionDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, const double& height, bool updateCurves = false);
 
 /// @brief Retrieves the "x" position of a TextGlyph object within a specific layout.
 /// This function fetches the "x" coordinate of the bounding box of a TextGlyph object, identified by its associated model entity ID and within a specified layout of the SBML document. The layout is determined by its index. Defaults for graphicalObjectIndex and textGlyphIndex are 0. If the TextGlyph object or the layout does not exist, the function returns 0.0.


### PR DESCRIPTION
In particular:
* The colors list was being constantly copied everywhere.  Now it's never copied at all.
* Any time a set position or size function was called, the curves were always updated a la autolayout.  It's still possible to move things with that functionality, but by default, it no longer does this.