### PR TITLE
Some new features are added + Some bugs are fixed

### DIFF
--- a/src/autolayout/libsbmlnetwork_autolayout.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout.cpp
@@ -165,33 +165,33 @@ void updateCompartmentExtents(Model *model, Layout *layout) {
 void updateCompartmentExtents(BoundingBox *compartmentGlyphBoundingBox, BoundingBox *speciesGlyphBoundingBox) {
     const double padding = getDefaultAutoLayoutPadding();
     if (speciesGlyphBoundingBox->x() - padding < compartmentGlyphBoundingBox->x()) {
-        compartmentGlyphBoundingBox->setWidth(compartmentGlyphBoundingBox->width() +
+        compartmentGlyphBoundingBox->setWidth(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->width() +
                                               (compartmentGlyphBoundingBox->x() -
-                                               (speciesGlyphBoundingBox->x() - padding)));
-        compartmentGlyphBoundingBox->setX(speciesGlyphBoundingBox->x() - padding);
+                                               (speciesGlyphBoundingBox->x() - padding))));
+        compartmentGlyphBoundingBox->setX(roundToTwoDecimalPlaces(speciesGlyphBoundingBox->x() - padding));
     }
     if (speciesGlyphBoundingBox->y() - padding < compartmentGlyphBoundingBox->y()) {
-        compartmentGlyphBoundingBox->setHeight(compartmentGlyphBoundingBox->height() +
+        compartmentGlyphBoundingBox->setHeight(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->height() +
                                                (compartmentGlyphBoundingBox->y() -
-                                                (speciesGlyphBoundingBox->y() - padding)));
+                                                (speciesGlyphBoundingBox->y() - padding))));
         compartmentGlyphBoundingBox->setY(speciesGlyphBoundingBox->y() - padding);
     }
     if (speciesGlyphBoundingBox->x() + speciesGlyphBoundingBox->width() + padding >
         compartmentGlyphBoundingBox->x() + compartmentGlyphBoundingBox->width()) {
-        compartmentGlyphBoundingBox->setWidth(compartmentGlyphBoundingBox->width()
+        compartmentGlyphBoundingBox->setWidth(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->width()
                                               + (speciesGlyphBoundingBox->x() + speciesGlyphBoundingBox->width() +
                                                  padding)
                                               - (compartmentGlyphBoundingBox->x() +
-                                                 compartmentGlyphBoundingBox->width()));
+                                                 compartmentGlyphBoundingBox->width())));
     }
     if (speciesGlyphBoundingBox->y() + speciesGlyphBoundingBox->height() + padding >
         compartmentGlyphBoundingBox->y() + compartmentGlyphBoundingBox->height()) {
-        compartmentGlyphBoundingBox->setHeight(compartmentGlyphBoundingBox->height()
+        compartmentGlyphBoundingBox->setHeight(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->height()
                                                +
                                                (speciesGlyphBoundingBox->y() + speciesGlyphBoundingBox->height() +
                                                 padding)
                                                - (compartmentGlyphBoundingBox->y() +
-                                                  compartmentGlyphBoundingBox->height()));
+                                                  compartmentGlyphBoundingBox->height())));
     }
 }
 
@@ -203,24 +203,24 @@ updateCompartmentExtents(BoundingBox *compartmentGlyphBoundingBox, Curve *reacti
     double reactionCenterY = 0.5 * (reactionCurve->getCurveSegment(0)->getStart()->y() +
                                     reactionCurve->getCurveSegment(0)->getEnd()->y());
     if (reactionCenterX - padding < compartmentGlyphBoundingBox->x()) {
-        compartmentGlyphBoundingBox->setWidth(compartmentGlyphBoundingBox->width() +
-                                              (compartmentGlyphBoundingBox->x() - (reactionCenterX - padding)));
+        compartmentGlyphBoundingBox->setWidth(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->width() +
+                                              (compartmentGlyphBoundingBox->x() - (reactionCenterX - padding))));
         compartmentGlyphBoundingBox->setX(reactionCenterX - padding);
     }
     if (reactionCenterY - padding < compartmentGlyphBoundingBox->y()) {
-        compartmentGlyphBoundingBox->setHeight(compartmentGlyphBoundingBox->height() +
-                                               (compartmentGlyphBoundingBox->y() - (reactionCenterY - padding)));
+        compartmentGlyphBoundingBox->setHeight(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->height() +
+                                               (compartmentGlyphBoundingBox->y() - (reactionCenterY - padding))));
         compartmentGlyphBoundingBox->setY(reactionCenterY - padding);
     }
     if (reactionCenterX + padding > compartmentGlyphBoundingBox->x() + compartmentGlyphBoundingBox->width()) {
-        compartmentGlyphBoundingBox->setWidth(compartmentGlyphBoundingBox->width()
+        compartmentGlyphBoundingBox->setWidth(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->width()
                                               + (reactionCenterX + padding) - (compartmentGlyphBoundingBox->x() +
-                                                                               compartmentGlyphBoundingBox->width()));
+                                                                               compartmentGlyphBoundingBox->width())));
     }
     if (reactionCenterY + padding > compartmentGlyphBoundingBox->y() + compartmentGlyphBoundingBox->height()) {
-        compartmentGlyphBoundingBox->setHeight(compartmentGlyphBoundingBox->height()
+        compartmentGlyphBoundingBox->setHeight(roundToTwoDecimalPlaces(compartmentGlyphBoundingBox->height()
                                                + (reactionCenterY + padding) - (compartmentGlyphBoundingBox->y() +
-                                                                                compartmentGlyphBoundingBox->height()));
+                                                                                compartmentGlyphBoundingBox->height())));
     }
 }
 
@@ -231,13 +231,11 @@ void updateLayoutDimensions(Layout *layout) {
         layout->getDimensions()->setHeight(0);
         return;
     } else {
-        double minX;
-        double minY;
         double maxX;
         double maxY;
-        extractExtents(layout, minX, minY, maxX, maxY);
-        layout->getDimensions()->setWidth(roundToTwoDecimalPlaces(maxX - minX));
-        layout->getDimensions()->setHeight(roundToTwoDecimalPlaces(maxY - minY));
+        extractExtents(layout, maxX, maxY);
+        layout->getDimensions()->setWidth(roundToTwoDecimalPlaces(maxX));
+        layout->getDimensions()->setHeight(roundToTwoDecimalPlaces(maxY));
     }
 }
 
@@ -269,9 +267,9 @@ const bool autolayoutMayStillConverge(const double &stiffness, const double &gra
     return false;
 }
 
-void extractExtents(Layout *layout, double &minX, double &minY, double &maxX, double &maxY) {
-    minX = INT_MAX;
-    minY = INT_MAX;
+void extractExtents(Layout *layout, double &maxX, double &maxY) {
+    double minX = INT_MAX;
+    double minY = INT_MAX;
     maxX = INT_MIN;
     maxY = INT_MIN;
     for (int i = 0; i < layout->getNumCompartmentGlyphs(); i++)

--- a/src/autolayout/libsbmlnetwork_autolayout.h
+++ b/src/autolayout/libsbmlnetwork_autolayout.h
@@ -50,7 +50,7 @@ const bool adjustLayoutDimensions(Layout *layout);
 
 const bool autolayoutMayStillConverge(const double &stiffness, const double &gravity);
 
-void extractExtents(Layout* layout, double &minX, double &minY, double &maxX, double &maxY);
+void extractExtents(Layout* layout, double &maxX, double &maxY);
 
 void extractExtents(BoundingBox* boundingBox, double &minX, double &minY, double &maxX, double &maxY);
 

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -149,15 +149,19 @@ class LibSBMLNetwork:
 
         return lib.c_api_autolayout(self.sbml_object, ctypes.c_int(max_num_connected_edges), self.use_name_as_text_label, reset_locked_nodes, locked_nodes_ptr, len(locked_nodes))
 
-    def autorender(self):
+    def autorender(self, max_num_connected_edges=3):
         """
         checks if a RenderInformation object does not exists in the SBMLDocument, then adds it to it, and set all the necessary features for it.
+
+        :Parameters:
+
+            - max_num_connected_edges (int, optional): an integer (default: 3) that determines the maximum number of connected edges to a node in the autorender algorithm (will set the criteria for creating alias nodes).
 
         :Returns:
 
             true on success and false if autorender algorithm was not applied successfully
         """
-        return lib.c_api_autorender(self.sbml_object)
+        return lib.c_api_autorender(self.sbml_object, ctypes.c_int(max_num_connected_edges))
 
     def align(self, nodes, alignment="center", ignore_locked_nodes=False):
         """
@@ -323,7 +327,7 @@ class LibSBMLNetwork:
 
             true on success and false if the Layout objects could not be removed
         """
-        return lib.c_api_removeAllLayouts(self.sbml_object)
+        return lib.c_api_removeLayouts(self.sbml_object)
 
     def createDefaultLayoutFeatures(self):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -1008,7 +1008,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the start point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentStartPointX(self.sbml_object, str(reaction_id).encode(), x, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentStartPointX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentStartPointY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1046,7 +1046,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the start point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentStartPointY(self.sbml_object, str(reaction_id).encode(), y, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentStartPointY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentEndPointX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1084,7 +1084,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the end point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentEndPointX(self.sbml_object, str(reaction_id).encode(), x, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentEndPointX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentEndPointY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1122,7 +1122,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the end point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentEndPointY(self.sbml_object, str(reaction_id).encode(), y, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentEndPointY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentBasePoint1X(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1160,7 +1160,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the first base point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint1X(self.sbml_object, str(reaction_id).encode(), x, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint1X(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
 
     def getSpeciesReferenceCurveSegmentBasePoint1Y(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
@@ -1200,7 +1200,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the first base point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint1Y(self.sbml_object, str(reaction_id).encode(), y, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint1Y(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentBasePoint2X(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1238,7 +1238,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the second base point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint2X(self.sbml_object, str(reaction_id).encode(), x, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint2X(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def getSpeciesReferenceCurveSegmentBasePoint2Y(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, curve_segment_index=0, layout_index=0):
         """
@@ -1276,7 +1276,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the second base point of the CurveSegment could not be set
         """
-        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint2Y(self.sbml_object, str(reaction_id).encode(), y, reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
+        return lib.c_api_setSpeciesReferenceCurveSegmentBasePoint2Y(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, curve_segment_index, layout_index)
 
     def isSetSpeciesReferenceBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
@@ -6956,6 +6956,165 @@ class LibSBMLNetwork:
             true if the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is a Text object and false otherwise
         """
         return lib.c_api_isText(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def isSetGeometricShapeBorderColor(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns whether the border color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the border color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetGeometricShapeBorderColor(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def getGeometricShapeBorderColor(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns the border color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the border color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+        """
+        lib.c_api_getGeometricShapeBorderColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getGeometricShapeBorderColor(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)).value.decode()
+
+    def setGeometricShapeBorderColor(self, id, border_color, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Sets the border color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - border_color (string): a string that determines the border color of the GeometricShape object
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border color of the GeometricShape object could not be set
+        """
+        return lib.c_api_setGeometricShapeBorderColor(self.sbml_object, str(id).encode(), str(border_color).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def isSetGeometricShapeBorderWidth(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns whether the border width of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the border width of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetGeometricShapeBorderWidth(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def getGeometricShapeBorderWidth(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns the border width of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the border width of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+        """
+        lib.c_api_getGeometricShapeBorderWidth.restype = ctypes.c_double
+        return lib.c_api_getGeometricShapeBorderWidth(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def setGeometricShapeBorderWidth(self, id, border_width, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Sets the border width of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - border_width (float): a float that determines the border width of the GeometricShape object
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+                true on success and false if the border width of the GeometricShape object could not be set
+            """
+        return lib.c_api_setGeometricShapeBorderWidth(self.sbml_object, str(id).encode(), ctypes.c_double(border_width), geometric_shape_index, graphical_object_index, layout_index)
+
+    def isSetGeometricShapeFillColor(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns whether the fill color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the fill color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetGeometricShapeFillColor(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)
+
+    def getGeometricShapeFillColor(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Returns the fill color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the fill color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+        """
+        lib.c_api_getGeometricShapeFillColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getGeometricShapeFillColor(self.sbml_object, str(id).encode(), geometric_shape_index, graphical_object_index, layout_index)).value.decode()
+
+    def setGeometricShapeFillColor(self, id, fill_color, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
+        """
+        Sets the fill color of the GeometricShape object with the given index associated with the model entity with the given id in the given SBMLDocument
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - fill_color (string): a string that determines the fill color of the GeometricShape object
+            - geometric_shape_index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object associated with the model entity with the given id in the given SBMLDocument
+            - graphical_object_index (int, optional): an integer (default: 0) that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+                true on success and false if the fill color of the GeometricShape object could not be set
+            """
+        return lib.c_api_setGeometricShapeFillColor(self.sbml_object, str(id).encode(), str(fill_color).encode(), geometric_shape_index, graphical_object_index, layout_index)
 
     def isSetGeometricShapeX(self, id, geometric_shape_index=0, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -3620,7 +3620,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), render_index)
 
-    def getReactionLineEndingBoundingBoxX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3635,10 +3635,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBoundingBoxX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3654,7 +3654,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxY(self, line_ending_id, render_index=0):
         """
@@ -3688,7 +3688,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), render_index)
 
-    def getReactionLineEndingBoundingBoxY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3703,10 +3703,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBoundingBoxY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3722,7 +3722,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxWidth(self, line_ending_id, render_index=0):
         """
@@ -3756,7 +3756,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), render_index)
 
-    def getReactionLineEndingBoundingBoxWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3771,10 +3771,10 @@ class LibSBMLNetwork:
 
             a float that determines the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBoundingBoxWidth.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3790,7 +3790,7 @@ class LibSBMLNetwork:
 
             true on success and false if the width of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxHeight(self, line_ending_id, render_index=0):
         """
@@ -3824,7 +3824,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), render_index)
 
-    def getReactionLineEndingBoundingBoxHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3839,10 +3839,10 @@ class LibSBMLNetwork:
 
             a float that determines the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBoundingBoxHeight.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3858,7 +3858,7 @@ class LibSBMLNetwork:
 
             true on success and false if the height of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingBorderColor(self, line_ending_id, render_index=0):
         """
@@ -3907,7 +3907,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBorderColor(self.sbml_object, str(line_ending_id).encode(), str(border_color).encode(), render_index)
 
-    def isSetReactionLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -3922,9 +3922,9 @@ class LibSBMLNetwork:
 
             true if the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getReactionLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3939,10 +3939,10 @@ class LibSBMLNetwork:
 
             a string that determines the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBorderColor.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getSpeciesReferenceLineEndingBorderColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setReactionLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3958,7 +3958,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
 
     def isSetLineEndingBorderWidth(self, line_ending_id, render_index=0):
@@ -4008,7 +4008,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBorderWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(border_width), render_index)
 
-    def isSetReactionLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4023,9 +4023,9 @@ class LibSBMLNetwork:
 
             true if the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getReactionLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4040,10 +4040,10 @@ class LibSBMLNetwork:
 
             a float that determines the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingBorderWidth.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getSpeciesReferenceLineEndingBorderWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4059,7 +4059,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border width of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getNumLineEndingBorderDashes(self, line_ending_id, render_index=0):
         """
@@ -4110,7 +4110,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingNthBorderDash(self.sbml_object, str(line_ending_id).encode(), index, border_dash, render_index)
 
-    def getNumReactionLineEndingBorderDashes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getNumSpeciesReferenceLineEndingBorderDashes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4125,9 +4125,9 @@ class LibSBMLNetwork:
 
             an integer that determines the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getNumReactionLineEndingBorderDashes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getNumSpeciesReferenceLineEndingBorderDashes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getReactionLineEndingNthBorderDash(self, reaction_id, index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4143,9 +4143,9 @@ class LibSBMLNetwork:
 
             an integer that determines the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getReactionLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4162,7 +4162,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border dash of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillColor(self, line_ending_id, render_index=0):
         """
@@ -4229,7 +4229,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillColorAsGradient(self.sbml_object, str(line_ending_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), render_index)
 
-    def isSetReactionLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4244,9 +4244,9 @@ class LibSBMLNetwork:
 
             true if the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getReactionLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4261,10 +4261,10 @@ class LibSBMLNetwork:
 
             a string that determines the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingFillColor.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getSpeciesReferenceLineEndingFillColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setReactionLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4280,9 +4280,9 @@ class LibSBMLNetwork:
 
             true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setReactionLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument as a gradient
 
@@ -4300,7 +4300,7 @@ class LibSBMLNetwork:
 
             true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillRule(self, line_ending_id, render_index=0):
         """
@@ -4349,7 +4349,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillRule(self.sbml_object, str(line_ending_id).encode(), str(fill_rule).encode(), render_index)
 
-    def isSetReactionLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4364,9 +4364,9 @@ class LibSBMLNetwork:
 
             true if the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getReactionLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4381,10 +4381,10 @@ class LibSBMLNetwork:
 
             a string that determines the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingFillRule.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getSpeciesReferenceLineEndingFillRule.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setReactionLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setSpeciesReferenceLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4400,7 +4400,7 @@ class LibSBMLNetwork:
 
             true on success and false if the fill rule of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getNumLineEndingGeometricShapes(self, line_ending_id, render_index=0):
         """
@@ -4417,7 +4417,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_getNumLineEndingGeometricShapes(self.sbml_object, str(line_ending_id).encode(), render_index)
 
-    def getNumReactionLineEndingGeometricShapes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getNumSpeciesReferenceLineEndingGeometricShapes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4432,7 +4432,7 @@ class LibSBMLNetwork:
 
             an integer that determines the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getNumReactionLineEndingGeometricShapes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getNumSpeciesReferenceLineEndingGeometricShapes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isLineEndingRectangle(self, line_ending_id, index=0, render_index=0):
         """
@@ -4450,7 +4450,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRectangle(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingRectangle(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingRectangle(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle
 
@@ -4466,7 +4466,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle and false otherwise
         """
-        return lib.c_api_isReactionLineEndingRectangle(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingRectangle(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingEllipse(self, line_ending_id, index=0, render_index=0):
         """
@@ -4484,7 +4484,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingEllipse(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingEllipse(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingEllipse(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse
 
@@ -4500,7 +4500,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse and false otherwise
         """
-        return lib.c_api_isReactionLineEndingEllipse(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingEllipse(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingPolygon(self, line_ending_id, index=0, render_index=0):
         """
@@ -4518,7 +4518,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingPolygon(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingPolygon(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingPolygon(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon
 
@@ -4534,7 +4534,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon and false otherwise
         """
-        return lib.c_api_isReactionLineEndingPolygon(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingPolygon(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingImage(self, line_ending_id, index=0, render_index=0):
         """
@@ -4552,7 +4552,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingImage(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingImage(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingImage(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image
 
@@ -4568,7 +4568,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image and false otherwise
         """
-        return lib.c_api_isReactionLineEndingImage(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingImage(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingRenderCurve(self, line_ending_id, index=0, render_index=0):
         """
@@ -4586,7 +4586,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRenderCurve(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingRenderCurve(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingRenderCurve(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve
 
@@ -4602,7 +4602,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve and false otherwise
         """
-        return lib.c_api_isReactionLineEndingRenderCurve(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingRenderCurve(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingText(self, line_ending_id, index=0, render_index=0):
         """
@@ -4620,7 +4620,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingText(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isReactionLineEndingText(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingText(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text
 
@@ -4636,7 +4636,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text and false otherwise
         """
-        return lib.c_api_isReactionLineEndingText(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingText(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeX(self, line_ending_id, index=0, render_index=0):
         """
@@ -4688,7 +4688,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4704,9 +4704,9 @@ class LibSBMLNetwork:
 
             true if the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4722,10 +4722,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4742,7 +4742,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeY(self, line_ending_id, index=0, render_index=0):
         """
@@ -4794,7 +4794,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4810,9 +4810,9 @@ class LibSBMLNetwork:
 
             true if the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4828,10 +4828,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4848,7 +4848,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeWidth(self, line_ending_id, index=0, render_index=0):
         """
@@ -4900,7 +4900,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4916,9 +4916,9 @@ class LibSBMLNetwork:
 
             true if the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4934,10 +4934,10 @@ class LibSBMLNetwork:
 
             a float that determines the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeWidth.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4954,7 +4954,7 @@ class LibSBMLNetwork:
 
             true on success and false if the width of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeHeight(self, line_ending_id, index=0, render_index=0):
         """
@@ -5006,7 +5006,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5022,9 +5022,9 @@ class LibSBMLNetwork:
 
             true if the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5040,10 +5040,10 @@ class LibSBMLNetwork:
 
             a float that determines the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeHeight.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5060,7 +5060,7 @@ class LibSBMLNetwork:
 
             true on success and false if the height of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRatio(self, line_ending_id, index=0, render_index=0):
         """
@@ -5112,7 +5112,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRatio(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(ratio), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5128,9 +5128,9 @@ class LibSBMLNetwork:
 
             true if the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5146,10 +5146,10 @@ class LibSBMLNetwork:
 
             a float that determines the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeRatio.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5166,7 +5166,7 @@ class LibSBMLNetwork:
 
             true on success and false if the ratio of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5218,7 +5218,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x_radius), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5234,9 +5234,9 @@ class LibSBMLNetwork:
 
             true if the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5252,10 +5252,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5272,7 +5272,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-radius of the border of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5324,7 +5324,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y_radius), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5340,9 +5340,9 @@ class LibSBMLNetwork:
 
             true if the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5358,10 +5358,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5378,7 +5378,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-radius of the border of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5430,7 +5430,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeCenterX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_x), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5446,9 +5446,9 @@ class LibSBMLNetwork:
 
             true if the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5464,10 +5464,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeCenterX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5484,7 +5484,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5536,7 +5536,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeCenterY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_y), render_index, index)
 
-    def isSetReactionLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5552,9 +5552,9 @@ class LibSBMLNetwork:
 
             true if the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5570,10 +5570,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeCenterY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5590,7 +5590,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the center of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRadiusX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5642,7 +5642,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_x), index, render_index)
 
-    def isSetReactionLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5658,9 +5658,9 @@ class LibSBMLNetwork:
 
             true if the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5676,10 +5676,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeRadiusX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5696,7 +5696,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-radius of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5748,7 +5748,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_y), render_index, index)
 
-    def isSetReactionLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5764,9 +5764,9 @@ class LibSBMLNetwork:
 
             true if the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getReactionLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5782,10 +5782,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeRadiusY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5802,7 +5802,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-radius of the GeometricShape object could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeNumSegments(self, line_ending_id, index=0, render_index=0):
         """
@@ -5820,7 +5820,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_getLineEndingGeometricShapeNumSegments(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def getReactionLineEndingGeometricShapeNumSegments(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeNumSegments(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5836,7 +5836,7 @@ class LibSBMLNetwork:
 
             an integer that determines the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getReactionLineEndingGeometricShapeNumSegments(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingGeometricShapeSegmentCubicBezier(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5855,7 +5855,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(line_ending_id).encode(), segment_index, index, render_index)
 
-    def isReactionLineEndingGeometricShapeSegmentCubicBezier(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment
 
@@ -5872,7 +5872,7 @@ class LibSBMLNetwork:
 
             true if the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment and false otherwise
         """
-        return lib.c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeSegmentX(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5910,7 +5910,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5927,10 +5927,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeSegmentX.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5948,7 +5948,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the segment could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeSegmentY(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5986,7 +5986,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6003,10 +6003,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeSegmentY.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6024,7 +6024,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the segment could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6062,7 +6062,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6079,10 +6079,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBasePoint1X.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6100,7 +6100,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the first base point of the segment could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6138,7 +6138,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6155,10 +6155,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBasePoint1Y.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6176,7 +6176,7 @@ class LibSBMLNetwork:
 
                 true on success and false if the y-coordinate of the first base point of the segment could not be set
             """
-        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint2X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6214,7 +6214,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6231,10 +6231,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6252,7 +6252,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the second base point of the segment could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint2Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6290,7 +6290,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getReactionLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6307,10 +6307,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getReactionLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
-        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setReactionLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6328,7 +6328,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the second base point of the segment could not be set
         """
-        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetBorderColor(self, id, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -3616,6 +3616,42 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), render_index)
 
+    def getSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x (float): a float that determines the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
     def getLineEndingBoundingBoxY(self, line_ending_id, render_index=0):
         """
         Returns the y-coordinate of the bounding box of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -3647,6 +3683,42 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the bounding box of the LineEnding object could not be set
         """
         return lib.c_api_setLineEndingBoundingBoxY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), render_index)
+
+    def getSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y (float): a float that determines the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxWidth(self, line_ending_id, render_index=0):
         """
@@ -3680,6 +3752,42 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), render_index)
 
+    def getSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - width (float): a float that determines the width of the bounding box of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the width of the bounding box of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
     def getLineEndingBoundingBoxHeight(self, line_ending_id, render_index=0):
         """
         Returns the height of the bounding box of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -3711,6 +3819,42 @@ class LibSBMLNetwork:
             true on success and false if the height of the bounding box of the LineEnding object could not be set
         """
         return lib.c_api_setLineEndingBoundingBoxHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), render_index)
+
+    def getSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - height (float): a float that determines the height of the bounding box of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the height of the bounding box of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingBorderColor(self, line_ending_id, render_index=0):
         """
@@ -3759,6 +3903,60 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBorderColor(self.sbml_object, str(line_ending_id).encode(), str(border_color).encode(), render_index)
 
+    def isSetSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns whether the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def getSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBorderColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+
+    def setSpeciesReferenceLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - border_color (string): a string that determines the border color of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border color of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+
     def isSetLineEndingBorderWidth(self, line_ending_id, render_index=0):
         """
         Returns whether the border width of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -3805,6 +4003,59 @@ class LibSBMLNetwork:
             true on success and false if the border width of the LineEnding object could not be set
         """
         return lib.c_api_setLineEndingBorderWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(border_width), render_index)
+
+    def isSetSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns whether the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def getSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a float that determines the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingBorderWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - border_width (float): a float that determines the border width of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border width of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getNumLineEndingBorderDashes(self, line_ending_id, render_index=0):
         """
@@ -3855,6 +4106,60 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingNthBorderDash(self.sbml_object, str(line_ending_id).encode(), index, border_dash, render_index)
 
+    def getNumSpeciesReferenceLineEndingBorderDashes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            an integer that determines the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        return lib.c_api_getNumSpeciesReferenceLineEndingBorderDashes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def getSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - index (int): an integer that determines the index of the border dash in the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            an integer that determines the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        return lib.c_api_getSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - index (int): an integer that determines the index of the border dash in the LineEnding object of the SpeciesReference object
+            - border_dash (int): an integer that determines the border dash of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border dash of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
+
     def isSetLineEndingFillColor(self, line_ending_id, render_index=0):
         """
         Returns whether the fill color of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -3901,6 +4206,59 @@ class LibSBMLNetwork:
             true on success and false if the fill color of the LineEnding object could not be set
         """
         return lib.c_api_setLineEndingFillColor(self.sbml_object, str(line_ending_id).encode(), str(fill_color).encode(), render_index)
+
+    def isSetSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns whether the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def getSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingFillColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+
+    def setSpeciesReferenceLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - fill_color (string): a string that determines the fill color of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillRule(self, line_ending_id, render_index=0):
         """
@@ -3949,6 +4307,59 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillRule(self.sbml_object, str(line_ending_id).encode(), str(fill_rule).encode(), render_index)
 
+    def isSetSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns whether the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def getSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingFillRule.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+
+    def setSpeciesReferenceLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - fill_rule (string): a string that determines the fill rule of the LineEnding object of the SpeciesReference object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill rule of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
     def getNumLineEndingGeometricShapes(self, line_ending_id, render_index=0):
         """
         Returns the number of GeometricShape objects in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -3963,6 +4374,23 @@ class LibSBMLNetwork:
             an integer that determines the number of GeometricShape objects in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
         """
         return lib.c_api_getNumLineEndingGeometricShapes(self.sbml_object, str(line_ending_id).encode(), render_index)
+
+    def getNumSpeciesReferenceLineEndingGeometricShapes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Returns the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            an integer that determines the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        return lib.c_api_getNumSpeciesReferenceLineEndingGeometricShapes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isLineEndingRectangle(self, line_ending_id, index=0, render_index=0):
         """
@@ -3980,6 +4408,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRectangle(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
+    def isSpeciesReferenceLineEndingRectangle(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingRectangle(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isLineEndingEllipse(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is an ellipse
@@ -3995,6 +4441,24 @@ class LibSBMLNetwork:
             true if the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is an ellipse and false otherwise
         """
         return lib.c_api_isLineEndingEllipse(self.sbml_object, str(line_ending_id).encode(), index, render_index)
+
+    def isSpeciesReferenceLineEndingEllipse(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingEllipse(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingPolygon(self, line_ending_id, index=0, render_index=0):
         """
@@ -4012,6 +4476,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingPolygon(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
+    def isSpeciesReferenceLineEndingPolygon(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingPolygon(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isLineEndingImage(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is an image
@@ -4027,6 +4509,24 @@ class LibSBMLNetwork:
             true if the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is an image and false otherwise
         """
         return lib.c_api_isLineEndingImage(self.sbml_object, str(line_ending_id).encode(), index, render_index)
+
+    def isSpeciesReferenceLineEndingImage(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingImage(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingRenderCurve(self, line_ending_id, index=0, render_index=0):
         """
@@ -4044,6 +4544,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRenderCurve(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
+    def isSpeciesReferenceLineEndingRenderCurve(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingRenderCurve(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isLineEndingText(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is text
@@ -4059,6 +4577,24 @@ class LibSBMLNetwork:
             true if the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is text and false otherwise
         """
         return lib.c_api_isLineEndingText(self.sbml_object, str(line_ending_id).encode(), index, render_index)
+
+    def isSpeciesReferenceLineEndingText(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingText(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeX(self, line_ending_id, index=0, render_index=0):
         """
@@ -4110,6 +4646,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), index, render_index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x (float): a float that determines the x-coordinate of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeY(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the y-coordinate of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4159,6 +4751,62 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the GeometricShape object could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), index, render_index)
+
+    def isSetSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y (float): a float that determines the y-coordinate of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeWidth(self, line_ending_id, index=0, render_index=0):
         """
@@ -4210,6 +4858,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), index, render_index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - width (float): a float that determines the width of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the width of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeHeight(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the height of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4259,6 +4963,62 @@ class LibSBMLNetwork:
             true on success and false if the height of the GeometricShape object could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), index, render_index)
+
+    def isSetSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - height (float): a float that determines the height of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the height of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRatio(self, line_ending_id, index=0, render_index=0):
         """
@@ -4310,6 +5070,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRatio(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(ratio), index, render_index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - ratio (float): a float that determines the ratio of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the ratio of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeBorderRadiusX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-radius of the border of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4359,6 +5175,62 @@ class LibSBMLNetwork:
             true on success and false if the x-radius of the border of the GeometricShape object could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x_radius), index, render_index)
+
+    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x_radius (float): a float that determines the x-radius of the border of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-radius of the border of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -4410,6 +5282,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y_radius), index, render_index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y_radius (float): a float that determines the y-radius of the border of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-radius of the border of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeCenterX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4459,6 +5387,62 @@ class LibSBMLNetwork:
             true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeCenterX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_x), index, render_index)
+
+    def isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - center_x (float): a float that determines the x-coordinate of the center of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterY(self, line_ending_id, index=0, render_index=0):
         """
@@ -4510,6 +5494,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeCenterY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_y), render_index, index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - center_y (float): a float that determines the y-coordinate of the center of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the center of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeRadiusX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-radius of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4559,6 +5599,62 @@ class LibSBMLNetwork:
             true on success and false if the x-radius of the GeometricShape object could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_x), index, render_index)
+
+    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - radius_x (float): a float that determines the x-radius of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-radius of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -4610,6 +5706,62 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_y), render_index, index)
 
+    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - radius_y (float): a float that determines the y-radius of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-radius of the GeometricShape object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeNumSegments(self, line_ending_id, index=0, render_index=0):
         """
         Returns the number of segments of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -4625,6 +5777,24 @@ class LibSBMLNetwork:
             an integer that determines the number of segments of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
         """
         return lib.c_api_getLineEndingGeometricShapeNumSegments(self.sbml_object, str(line_ending_id).encode(), index, render_index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeNumSegments(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            an integer that determines the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingGeometricShapeSegmentCubicBezier(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -4642,6 +5812,25 @@ class LibSBMLNetwork:
             true if the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is a cubic bezier segment and false otherwise
         """
         return lib.c_api_isLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(line_ending_id).encode(), segment_index, index, render_index)
+
+    def isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns whether the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true if the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment and false otherwise
+        """
+        return lib.c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeSegmentX(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -4679,6 +5868,46 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
+    def getSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the segment could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeSegmentY(self, line_ending_id, segment_index, index=0, render_index=0):
         """
         Returns the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -4714,6 +5943,46 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the segment could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the segment could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -4751,6 +6020,46 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the first base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the first base point of the segment could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeBasePoint1Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
         Returns the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -4786,6 +6095,198 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the first base point of the segment could not be set
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the first base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+                true on success and false if the y-coordinate of the first base point of the segment could not be set
+            """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getLineEndingGeometricShapeBasePoint2X(self, line_ending_id, segment_index, index=0, render_index=0):
+        """
+        Returns the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+
+        :Parameters:
+
+            - line_ending_id (string): a string that determines the id of the LineEnding object
+            - segment_index (int): an integer that determines the index of the segment
+            - render_index (int, optional): an integer (default: 0) that determines the index of the RenderInformation object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+        """
+        lib.c_api_getLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
+        return lib.c_api_getLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(line_ending_id).encode(), segment_index, index, render_index)
+
+    def setLineEndingGeometricShapeBasePoint2X(self, line_ending_id, segment_index, x, index=0, render_index=0):
+        """
+        Sets the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+
+        :Parameters:
+
+            - line_ending_id (string): a string that determines the id of the LineEnding object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the second base point of the segment
+            - render_index (int, optional): an integer (default: 0) that determines the index of the RenderInformation object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the second base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def getLineEndingGeometricShapeBasePoint2Y(self, line_ending_id, segment_index, index=0, render_index=0):
+        """
+        Returns the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+
+        :Parameters:
+
+            - line_ending_id (string): a string that determines the id of the LineEnding object
+            - segment_index (int): an integer that determines the index of the segment
+            - render_index (int, optional): an integer (default: 0) that determines the index of the RenderInformation object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+        """
+        lib.c_api_getLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
+        return lib.c_api_getLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(line_ending_id).encode(), segment_index, index, render_index)
+
+    def setLineEndingGeometricShapeBasePoint2Y(self, line_ending_id, y, segment_index, index=0, render_index=0):
+        """
+        Sets the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
+
+        :Parameters:
+
+            - line_ending_id (string): a string that determines the id of the LineEnding object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the second base point of the segment
+            - render_index (int, optional): an integer (default: 0) that determines the index of the RenderInformation object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
+
+    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Returns the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            a float that determines the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
+        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the second base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the SpeciesReference object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetBorderColor(self, id, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -3656,6 +3656,23 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
+    def setReactionLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the x-coordinate of the bounding box of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x (float): a float that determines the x-coordinate of the bounding box of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the bounding box of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, layout_index)
+
     def getLineEndingBoundingBoxY(self, line_ending_id, render_index=0):
         """
         Returns the y-coordinate of the bounding box of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -3723,6 +3740,23 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setReactionLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the y-coordinate of the bounding box of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y (float): a float that determines the y-coordinate of the bounding box of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the bounding box of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxWidth(self, line_ending_id, render_index=0):
         """
@@ -3792,6 +3826,23 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
+    def setReactionLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the width of the bounding box of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - width (float): a float that determines the width of the bounding box of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the width of the bounding box of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, layout_index)
+
     def getLineEndingBoundingBoxHeight(self, line_ending_id, render_index=0):
         """
         Returns the height of the bounding box of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -3859,6 +3910,23 @@ class LibSBMLNetwork:
             true on success and false if the height of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setReactionLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the height of the bounding box of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - height (float): a float that determines the height of the bounding box of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the height of the bounding box of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, layout_index)
 
     def isSetLineEndingBorderColor(self, line_ending_id, render_index=0):
         """
@@ -3960,6 +4028,22 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
+    def setReactionLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the border color of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - border_color (string): a string that determines the border color of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border color of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, layout_index)
 
     def isSetLineEndingBorderWidth(self, line_ending_id, render_index=0):
         """
@@ -4060,6 +4144,23 @@ class LibSBMLNetwork:
             true on success and false if the border width of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setReactionLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the border width of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - border_width (float): a float that determines the border width of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border width of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, layout_index)
 
     def getNumLineEndingBorderDashes(self, line_ending_id, render_index=0):
         """
@@ -4163,6 +4264,24 @@ class LibSBMLNetwork:
             true on success and false if the border dash of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setReactionLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the border dash with the given index of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - index (int): an integer that determines the index of the border dash in the LineEnding object of the Reaction object
+            - border_dash (int): an integer that determines the border dash of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the border dash of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, layout_index)
 
     def isSetLineEndingFillColor(self, line_ending_id, render_index=0):
         """
@@ -4302,6 +4421,42 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
+    def setReactionLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the fill color of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - fill_color (string): a string that determines the fill color of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, layout_index)
+
+    def setReactionLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the fill color of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string that determines the type of the gradient (default: "linear")
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, layout_index)
+
     def isSetLineEndingFillRule(self, line_ending_id, render_index=0):
         """
         Returns whether the fill rule of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4401,6 +4556,23 @@ class LibSBMLNetwork:
             true on success and false if the fill rule of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setReactionLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, layout_index=0):
+        """
+        Sets the fill rule of the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - fill_rule (string): a string that determines the fill rule of the LineEnding object of the Reaction object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill rule of the LineEnding object of the Reaction object could not be set
+        """
+        return lib.c_api_setReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, layout_index)
 
     def getNumLineEndingGeometricShapes(self, line_ending_id, render_index=0):
         """
@@ -4744,6 +4916,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x (float): a float that determines the x-coordinate of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeY(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the y-coordinate of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -4849,6 +5039,24 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the GeometricShape object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y (float): a float that determines the y-coordinate of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeWidth(self, line_ending_id, index=0, render_index=0):
         """
@@ -4956,6 +5164,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the width of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - width (float): a float that determines the width of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the width of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeHeight(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the height of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -5061,6 +5287,24 @@ class LibSBMLNetwork:
             true on success and false if the height of the GeometricShape object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the height of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - height (float): a float that determines the height of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the height of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRatio(self, line_ending_id, index=0, render_index=0):
         """
@@ -5168,6 +5412,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the ratio of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - ratio (float): a float that determines the ratio of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the ratio of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeBorderRadiusX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-radius of the border of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -5273,6 +5535,24 @@ class LibSBMLNetwork:
             true on success and false if the x-radius of the border of the GeometricShape object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - x_radius (float): a float that determines the x-radius of the border of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-radius of the border of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5380,6 +5660,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - y_radius (float): a float that determines the y-radius of the border of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-radius of the border of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeCenterX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -5485,6 +5783,24 @@ class LibSBMLNetwork:
             true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - center_x (float): a float that determines the x-coordinate of the center of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5592,6 +5908,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - center_y (float): a float that determines the y-coordinate of the center of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the center of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeRadiusX(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the x-radius of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -5698,6 +6032,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-radius of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - radius_x (float): a float that determines the x-radius of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-radius of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, layout_index, index)
+
     def isSetLineEndingGeometricShapeRadiusY(self, line_ending_id, index=0, render_index=0):
         """
         Returns whether the y-radius of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument is set
@@ -5803,6 +6155,24 @@ class LibSBMLNetwork:
             true on success and false if the y-radius of the GeometricShape object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-radius of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - radius_y (float): a float that determines the y-radius of the GeometricShape object
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-radius of the GeometricShape object could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeNumSegments(self, line_ending_id, index=0, render_index=0):
         """
@@ -5950,6 +6320,25 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeSegmentY(self, line_ending_id, segment_index, index=0, render_index=0):
         """
         Returns the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -6025,6 +6414,25 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the segment could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6102,6 +6510,25 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the first base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the first base point of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeBasePoint1Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
         Returns the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -6177,6 +6604,25 @@ class LibSBMLNetwork:
                 true on success and false if the y-coordinate of the first base point of the segment could not be set
             """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the first base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the first base point of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint2X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6254,6 +6700,25 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
+    def setReactionLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - x (float): a float that determines the x-coordinate of the second base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the x-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, layout_index, index)
+
     def getLineEndingGeometricShapeBasePoint2Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
         Returns the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument
@@ -6329,6 +6794,25 @@ class LibSBMLNetwork:
             true on success and false if the y-coordinate of the second base point of the segment could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+
+    def setReactionLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, layout_index=0, index=0):
+        """
+        Sets the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the Reaction object with the given reaction_id, reaction_glyph_index and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - segment_index (int): an integer that determines the index of the segment
+            - y (float): a float that determines the y-coordinate of the second base point of the segment
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - index (int, optional): an integer (default: 0) that determines the index of the GeometricShape object in the LineEnding object of the Reaction object
+
+        :Returns:
+
+            true on success and false if the y-coordinate of the second base point of the segment could not be set
+        """
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, layout_index, index)
 
     def isSetBorderColor(self, id, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -3620,7 +3620,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), render_index)
 
-    def getSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBoundingBoxX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3635,10 +3635,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getReactionLineEndingBoundingBoxX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBoundingBoxX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3654,7 +3654,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBoundingBoxX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxY(self, line_ending_id, render_index=0):
         """
@@ -3688,7 +3688,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), render_index)
 
-    def getSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBoundingBoxY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3703,10 +3703,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getReactionLineEndingBoundingBoxY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBoundingBoxY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3722,7 +3722,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBoundingBoxY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxWidth(self, line_ending_id, render_index=0):
         """
@@ -3756,7 +3756,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), render_index)
 
-    def getSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBoundingBoxWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3771,10 +3771,10 @@ class LibSBMLNetwork:
 
             a float that determines the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getReactionLineEndingBoundingBoxWidth.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBoundingBoxWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the width of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3790,7 +3790,7 @@ class LibSBMLNetwork:
 
             true on success and false if the width of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBoundingBoxWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getLineEndingBoundingBoxHeight(self, line_ending_id, render_index=0):
         """
@@ -3824,7 +3824,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBoundingBoxHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), render_index)
 
-    def getSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBoundingBoxHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3839,10 +3839,10 @@ class LibSBMLNetwork:
 
             a float that determines the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getReactionLineEndingBoundingBoxHeight.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBoundingBoxHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the height of the bounding box of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3858,7 +3858,7 @@ class LibSBMLNetwork:
 
             true on success and false if the height of the bounding box of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBoundingBoxHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingBorderColor(self, line_ending_id, render_index=0):
         """
@@ -3907,7 +3907,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBorderColor(self.sbml_object, str(line_ending_id).encode(), str(border_color).encode(), render_index)
 
-    def isSetSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetReactionLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -3922,9 +3922,9 @@ class LibSBMLNetwork:
 
             true if the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getSpeciesReferenceLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBorderColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3939,10 +3939,10 @@ class LibSBMLNetwork:
 
             a string that determines the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBorderColor.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getReactionLineEndingBorderColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setSpeciesReferenceLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBorderColor(self, reaction_id, border_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -3958,7 +3958,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBorderColor(self.sbml_object, str(reaction_id).encode(), str(border_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
 
     def isSetLineEndingBorderWidth(self, line_ending_id, render_index=0):
@@ -4008,7 +4008,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingBorderWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(border_width), render_index)
 
-    def isSetSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetReactionLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4023,9 +4023,9 @@ class LibSBMLNetwork:
 
             true if the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getSpeciesReferenceLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingBorderWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4040,10 +4040,10 @@ class LibSBMLNetwork:
 
             a float that determines the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingBorderWidth.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        lib.c_api_getReactionLineEndingBorderWidth.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingBorderWidth(self, reaction_id, border_width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border width of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4059,7 +4059,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border width of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingBorderWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(border_width), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getNumLineEndingBorderDashes(self, line_ending_id, render_index=0):
         """
@@ -4110,7 +4110,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingNthBorderDash(self.sbml_object, str(line_ending_id).encode(), index, border_dash, render_index)
 
-    def getNumSpeciesReferenceLineEndingBorderDashes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getNumReactionLineEndingBorderDashes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4125,9 +4125,9 @@ class LibSBMLNetwork:
 
             an integer that determines the number of border dashes of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getNumSpeciesReferenceLineEndingBorderDashes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getNumReactionLineEndingBorderDashes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingNthBorderDash(self, reaction_id, index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4143,9 +4143,9 @@ class LibSBMLNetwork:
 
             an integer that determines the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getReactionLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingNthBorderDash(self, reaction_id, index, border_dash, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the border dash with the given index of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4162,7 +4162,7 @@ class LibSBMLNetwork:
 
             true on success and false if the border dash of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingNthBorderDash(self.sbml_object, str(reaction_id).encode(), index, border_dash, reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillColor(self, line_ending_id, render_index=0):
         """
@@ -4229,7 +4229,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillColorAsGradient(self.sbml_object, str(line_ending_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), render_index)
 
-    def isSetSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetReactionLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4244,9 +4244,9 @@ class LibSBMLNetwork:
 
             true if the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4261,10 +4261,10 @@ class LibSBMLNetwork:
 
             a string that determines the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingFillColor.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getReactionLineEndingFillColor.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setSpeciesReferenceLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingFillColor(self, reaction_id, fill_color, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4280,9 +4280,9 @@ class LibSBMLNetwork:
 
             true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def setSpeciesReferenceLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument as a gradient
 
@@ -4300,7 +4300,7 @@ class LibSBMLNetwork:
 
             true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillRule(self, line_ending_id, render_index=0):
         """
@@ -4349,7 +4349,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillRule(self.sbml_object, str(line_ending_id).encode(), str(fill_rule).encode(), render_index)
 
-    def isSetSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def isSetReactionLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4364,9 +4364,9 @@ class LibSBMLNetwork:
 
             true if the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_isSetReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
-    def getSpeciesReferenceLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getReactionLineEndingFillRule(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4381,10 +4381,10 @@ class LibSBMLNetwork:
 
             a string that determines the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingFillRule.restype = ctypes.c_char_p
-        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
+        lib.c_api_getReactionLineEndingFillRule.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)).value.decode()
 
-    def setSpeciesReferenceLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def setReactionLineEndingFillRule(self, reaction_id, fill_rule, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Sets the fill rule of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4400,7 +4400,7 @@ class LibSBMLNetwork:
 
             true on success and false if the fill rule of the LineEnding object of the SpeciesReference object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_setReactionLineEndingFillRule(self.sbml_object, str(reaction_id).encode(), str(fill_rule).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def getNumLineEndingGeometricShapes(self, line_ending_id, render_index=0):
         """
@@ -4417,7 +4417,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_getNumLineEndingGeometricShapes(self.sbml_object, str(line_ending_id).encode(), render_index)
 
-    def getNumSpeciesReferenceLineEndingGeometricShapes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+    def getNumReactionLineEndingGeometricShapes(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4432,7 +4432,7 @@ class LibSBMLNetwork:
 
             an integer that determines the number of GeometricShape objects in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getNumSpeciesReferenceLineEndingGeometricShapes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+        return lib.c_api_getNumReactionLineEndingGeometricShapes(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isLineEndingRectangle(self, line_ending_id, index=0, render_index=0):
         """
@@ -4450,7 +4450,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRectangle(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingRectangle(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingRectangle(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle
 
@@ -4466,7 +4466,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a rectangle and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingRectangle(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingRectangle(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingEllipse(self, line_ending_id, index=0, render_index=0):
         """
@@ -4484,7 +4484,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingEllipse(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingEllipse(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingEllipse(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse
 
@@ -4500,7 +4500,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an ellipse and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingEllipse(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingEllipse(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingPolygon(self, line_ending_id, index=0, render_index=0):
         """
@@ -4518,7 +4518,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingPolygon(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingPolygon(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingPolygon(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon
 
@@ -4534,7 +4534,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a polygon and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingPolygon(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingPolygon(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingImage(self, line_ending_id, index=0, render_index=0):
         """
@@ -4552,7 +4552,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingImage(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingImage(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingImage(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image
 
@@ -4568,7 +4568,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is an image and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingImage(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingImage(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingRenderCurve(self, line_ending_id, index=0, render_index=0):
         """
@@ -4586,7 +4586,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingRenderCurve(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingRenderCurve(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingRenderCurve(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve
 
@@ -4602,7 +4602,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a render curve and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingRenderCurve(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingRenderCurve(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingText(self, line_ending_id, index=0, render_index=0):
         """
@@ -4620,7 +4620,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingText(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def isSpeciesReferenceLineEndingText(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingText(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text
 
@@ -4636,7 +4636,7 @@ class LibSBMLNetwork:
 
             true if the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is text and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingText(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingText(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeX(self, line_ending_id, index=0, render_index=0):
         """
@@ -4688,7 +4688,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4704,9 +4704,9 @@ class LibSBMLNetwork:
 
             true if the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4722,10 +4722,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeX(self, reaction_id, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4742,7 +4742,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeY(self, line_ending_id, index=0, render_index=0):
         """
@@ -4794,7 +4794,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4810,9 +4810,9 @@ class LibSBMLNetwork:
 
             true if the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4828,10 +4828,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeY(self, reaction_id, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4848,7 +4848,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeWidth(self, line_ending_id, index=0, render_index=0):
         """
@@ -4900,7 +4900,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeWidth(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(width), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -4916,9 +4916,9 @@ class LibSBMLNetwork:
 
             true if the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeWidth(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4934,10 +4934,10 @@ class LibSBMLNetwork:
 
             a float that determines the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeWidth.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeWidth(self, reaction_id, width, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the width of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -4954,7 +4954,7 @@ class LibSBMLNetwork:
 
             true on success and false if the width of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeWidth(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(width), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeHeight(self, line_ending_id, index=0, render_index=0):
         """
@@ -5006,7 +5006,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeHeight(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(height), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5022,9 +5022,9 @@ class LibSBMLNetwork:
 
             true if the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeHeight(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5040,10 +5040,10 @@ class LibSBMLNetwork:
 
             a float that determines the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeHeight.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeHeight(self, reaction_id, height, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the height of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5060,7 +5060,7 @@ class LibSBMLNetwork:
 
             true on success and false if the height of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeHeight(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(height), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRatio(self, line_ending_id, index=0, render_index=0):
         """
@@ -5112,7 +5112,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRatio(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(ratio), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5128,9 +5128,9 @@ class LibSBMLNetwork:
 
             true if the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeRatio(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5146,10 +5146,10 @@ class LibSBMLNetwork:
 
             a float that determines the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeRatio.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeRatio(self, reaction_id, ratio, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the ratio of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5166,7 +5166,7 @@ class LibSBMLNetwork:
 
             true on success and false if the ratio of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeRatio(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(ratio), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5218,7 +5218,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x_radius), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5234,9 +5234,9 @@ class LibSBMLNetwork:
 
             true if the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5252,10 +5252,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBorderRadiusX(self, reaction_id, x_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5272,7 +5272,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-radius of the border of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(x_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeBorderRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5324,7 +5324,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y_radius), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5340,9 +5340,9 @@ class LibSBMLNetwork:
 
             true if the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5358,10 +5358,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBorderRadiusY(self, reaction_id, y_radius, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-radius of the border of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5378,7 +5378,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-radius of the border of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBorderRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(y_radius), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5430,7 +5430,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeCenterX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_x), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5446,9 +5446,9 @@ class LibSBMLNetwork:
 
             true if the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeCenterX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5464,10 +5464,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeCenterX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeCenterX(self, reaction_id, center_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5484,7 +5484,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the center of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeCenterX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeCenterY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5536,7 +5536,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeCenterY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(center_y), render_index, index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5552,9 +5552,9 @@ class LibSBMLNetwork:
 
             true if the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeCenterY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5570,10 +5570,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeCenterY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeCenterY(self, reaction_id, center_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the center of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5590,7 +5590,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the center of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeCenterY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(center_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRadiusX(self, line_ending_id, index=0, render_index=0):
         """
@@ -5642,7 +5642,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_x), index, render_index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5658,9 +5658,9 @@ class LibSBMLNetwork:
 
             true if the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeRadiusX(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5676,10 +5676,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeRadiusX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeRadiusX(self, reaction_id, radius_x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5696,7 +5696,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-radius of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeRadiusX(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetLineEndingGeometricShapeRadiusY(self, line_ending_id, index=0, render_index=0):
         """
@@ -5748,7 +5748,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeRadiusY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(radius_y), render_index, index)
 
-    def isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isSetReactionLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
 
@@ -5764,9 +5764,9 @@ class LibSBMLNetwork:
 
             true if the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set and false otherwise
         """
-        return lib.c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isSetReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeRadiusY(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5782,10 +5782,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeRadiusY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeRadiusY(self, reaction_id, radius_y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-radius of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5802,7 +5802,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-radius of the GeometricShape object could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeRadiusY(self.sbml_object, str(reaction_id).encode(), ctypes.c_double(radius_y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeNumSegments(self, line_ending_id, index=0, render_index=0):
         """
@@ -5820,7 +5820,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_getLineEndingGeometricShapeNumSegments(self.sbml_object, str(line_ending_id).encode(), index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeNumSegments(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeNumSegments(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5836,7 +5836,7 @@ class LibSBMLNetwork:
 
             an integer that determines the number of segments of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_getReactionLineEndingGeometricShapeNumSegments(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isLineEndingGeometricShapeSegmentCubicBezier(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5855,7 +5855,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_isLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(line_ending_id).encode(), segment_index, index, render_index)
 
-    def isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def isReactionLineEndingGeometricShapeSegmentCubicBezier(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns whether the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment
 
@@ -5872,7 +5872,7 @@ class LibSBMLNetwork:
 
             true if the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is a cubic bezier segment and false otherwise
         """
-        return lib.c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeSegmentX(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5910,7 +5910,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentX(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5927,10 +5927,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeSegmentX.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeSegmentX(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -5948,7 +5948,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the segment could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeSegmentX(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeSegmentY(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -5986,7 +5986,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeSegmentY(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6003,10 +6003,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeSegmentY.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeSegmentY(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6024,7 +6024,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the segment could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeSegmentY(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6062,7 +6062,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6079,10 +6079,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBasePoint1X.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBasePoint1X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6100,7 +6100,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the first base point of the segment could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint1Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6138,7 +6138,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6155,10 +6155,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBasePoint1Y.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBasePoint1Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the first base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6176,7 +6176,7 @@ class LibSBMLNetwork:
 
                 true on success and false if the y-coordinate of the first base point of the segment could not be set
             """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint1Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint2X(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6214,7 +6214,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(x), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6231,10 +6231,10 @@ class LibSBMLNetwork:
 
             a float that determines the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBasePoint2X.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBasePoint2X(self, reaction_id, segment_index, x, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the x-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6252,7 +6252,7 @@ class LibSBMLNetwork:
 
             true on success and false if the x-coordinate of the second base point of the segment could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2X(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(x), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def getLineEndingGeometricShapeBasePoint2Y(self, line_ending_id, segment_index, index=0, render_index=0):
         """
@@ -6290,7 +6290,7 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(line_ending_id).encode(), ctypes.c_double(y), segment_index, index, render_index)
 
-    def getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def getReactionLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Returns the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6307,10 +6307,10 @@ class LibSBMLNetwork:
 
             a float that determines the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
         """
-        lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
-        return lib.c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        lib.c_api_getReactionLineEndingGeometricShapeBasePoint2Y.restype = ctypes.c_double
+        return lib.c_api_getReactionLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
-    def setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
+    def setReactionLineEndingGeometricShapeBasePoint2Y(self, reaction_id, segment_index, y, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0, index=0):
         """
         Sets the y-coordinate of the second base point of the segment with the given segment_index of the GeometricShape object with the given index in the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument
 
@@ -6328,7 +6328,7 @@ class LibSBMLNetwork:
 
             true on success and false if the y-coordinate of the second base point of the segment could not be set
         """
-        return lib.c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
+        return lib.c_api_setReactionLineEndingGeometricShapeBasePoint2Y(self.sbml_object, str(reaction_id).encode(), segment_index, ctypes.c_double(y), reaction_glyph_index, species_reference_glyph_index, layout_index, index)
 
     def isSetBorderColor(self, id, graphical_object_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -4211,6 +4211,24 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingFillColor(self.sbml_object, str(line_ending_id).encode(), str(fill_color).encode(), render_index)
 
+    def setLineEndingFillColorAsGradient(self, line_ending_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", render_index = 0):
+        """
+        Sets the fill color of the LineEnding object with the given line_ending_id and render_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - line_ending_id (string): a string that determines the id of the LineEnding object
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string that determines the type of the gradient (default: "linear")
+            - render_index (int, optional): an integer (default: 0) that determines the index of the RenderInformation object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the LineEnding object could not be set
+        """
+        return lib.c_api_setLineEndingFillColorAsGradient(self.sbml_object, str(line_ending_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), render_index)
+
     def isSetSpeciesReferenceLineEndingFillColor(self, reaction_id, reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
         """
         Returns whether the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument is set
@@ -4263,6 +4281,26 @@ class LibSBMLNetwork:
             true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
         """
         return lib.c_api_setSpeciesReferenceLineEndingFillColor(self.sbml_object, str(reaction_id).encode(), str(fill_color).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
+
+    def setSpeciesReferenceLineEndingFillColorAsGradient(self, reaction_id, stop_colors = [], stop_offsets = [], gradient_type = "linear", reaction_glyph_index=0, species_reference_glyph_index=0, layout_index=0):
+        """
+        Sets the fill color of the LineEnding object of the SpeciesReference object with the given reaction_id, reaction_glyph_index, species_reference_glyph_index and layout_index in the given SBMLDocument as a gradient
+
+       :Parameters
+
+            - reaction_id (string): a string that determines the id of the Reaction object
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string that determines the type of the gradient (default: "linear")
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph object in the given SBMLDocument
+            - species_reference_glyph_index (int, optional): an integer (default: 0) that determines the index of the SpeciesReferenceGlyph object in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the LineEnding object of the SpeciesReference object could not be set
+        """
+        return lib.c_api_setSpeciesReferenceLineEndingFillColorAsGradient(self.sbml_object, str(reaction_id).encode(), (ctypes.c_char_p * len(stop_colors))(*[str(color).encode() for color in stop_colors]), (ctypes.c_double * len(stop_offsets))(*stop_offsets), len(stop_colors), str(gradient_type).encode(), reaction_glyph_index, species_reference_glyph_index, layout_index)
 
     def isSetLineEndingFillRule(self, line_ending_id, render_index=0):
         """
@@ -6850,6 +6888,40 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setFillColor(self.sbml_object, str(id).encode(), str(fill_color).encode(), graphical_object_index, layout_index)
 
+    def setFillColorAsGradient(self, id, stop_colors = [], stop_offsets = [], gradient_type = "linear", graphical_object_index=0, layout_index=0):
+        """
+        Sets the fill color of the GraphicalObject associated with the model entity with the given id, graphical_object_index, and layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - id (string): a string that determines the id of the model entity
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of the GraphicalObject could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setFillColorAsGradient(self.sbml_object, str(id).encode(), str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), graphical_object_index, layout_index)
+
     def getCompartmentsFillColor(self):
         """
         Returns the default fill color of the CompartmentGlyph objects in the given SBMLDocument
@@ -6875,6 +6947,38 @@ class LibSBMLNetwork:
             true on success and false if the fill color of all the CompartmentGlyph object could not be set
         """
         return lib.c_api_setCompartmentsFillColor(self.sbml_object, str(fill_color).encode(), layout_index)
+
+    def setCompartmentsFillColorAsGradient(self, stop_colors = [], stop_offsets = [], gradient_type = "linear", layout_index=0):
+        """
+        Sets the fill color of all the CompartmentGlyph object with the given layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of all the CompartmentGlyph object could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setCompartmentsFillColorAsGradient(self.sbml_object, str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), layout_index)
 
     def getSpeciesFillColor(self):
         """
@@ -6902,6 +7006,38 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setSpeciesFillColor(self.sbml_object, str(fill_color).encode(), layout_index)
 
+    def setSpeciesFillColorAsGradient(self, stop_colors = [], stop_offsets = [], gradient_type = "linear", layout_index=0):
+        """
+        Sets the fill color of all the SpeciesGlyph object with the given layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of all the SpeciesGlyph object could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setSpeciesFillColorAsGradient(self.sbml_object, str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), layout_index)
+
     def getReactionsFillColor(self):
         """
         Returns the default fill color of the ReactionGlyph objects in the given SBMLDocument
@@ -6928,6 +7064,38 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setReactionsFillColor(self.sbml_object, str(fill_color).encode(), layout_index)
 
+    def setReactionsFillColorAsGradient(self, stop_colors = [], stop_offsets = [], gradient_type = "linear", layout_index=0):
+        """
+        Sets the fill color of all the ReactionGlyph object with the given layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of all the ReactionGlyph object could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setReactionsFillColorAsGradient(self.sbml_object, str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), layout_index)
+
     def setLineEndingsFillColor(self, fill_color, layout_index=0):
         """
         Sets the fill color of all the LineEnding object with the given layout_index in the given SBMLDocument
@@ -6943,6 +7111,38 @@ class LibSBMLNetwork:
         """
         return lib.c_api_setLineEndingsFillColor(self.sbml_object, str(fill_color).encode(), layout_index)
 
+    def setLineEndingsFillColorAsGradient(self, stop_colors = [], stop_offsets = [], gradient_type = "linear", layout_index=0):
+        """
+        Sets the fill color of all the LineEnding object with the given layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of all the LineEnding object could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setLineEndingsFillColorAsGradient(self.sbml_object, str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), layout_index)
+
     def setFillColors(self, fill_color, layout_index=0):
         """
         Sets the fill color of all the GraphicalObject objects with the given layout_index in the given SBMLDocument
@@ -6957,6 +7157,38 @@ class LibSBMLNetwork:
             true on success and false if the fill color of all the GraphicalObject object could not be set
         """
         return lib.c_api_setFillColors(self.sbml_object, str(fill_color).encode(), layout_index)
+
+    def setFillColorsAsGradient(self, stop_colors = [], stop_offsets = [], gradient_type = "linear", layout_index=0):
+        """
+        Sets the fill color of all the GraphicalObject objects with the given layout_index in the given SBMLDocument as a gradient
+
+        :Parameters:
+
+            - stop_colors (list): a list of strings that determines the stop colors of the gradient
+            - stop_offsets (list): a list of floats that determines the stop offsets of the gradient
+            - gradient_type (string, optional): a string (default: "linear") that determines the type of the gradient
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the fill color of all the GraphicalObject object could not be set
+        """
+        if len(stop_colors) != len(stop_offsets):
+            raise ValueError("The number of stop colors list and stop offsets list should be the same")
+
+        stop_colors_ptr = None
+        if stop_colors is not None:
+            stop_colors_ptr = (ctypes.c_char_p * len(stop_colors))()
+            for i in range(len(stop_colors)):
+                stop_colors_ptr[i] = ctypes.c_char_p(stop_colors[i].encode())
+
+        stop_offsets_ptr = None
+        if stop_offsets is not None:
+            stop_offsets_ptr = (ctypes.c_double * len(stop_offsets))()
+            for i in range(len(stop_offsets)):
+                stop_offsets_ptr[i] = ctypes.c_double(stop_offsets[i])
+
+        return lib.c_api_setFillColorsAsGradient(self.sbml_object, str(gradient_type).encode(), stop_colors_ptr, stop_offsets_ptr, len(stop_colors), layout_index)
 
     def isSetFillRule(self, id, graphical_object_index=0, layout_index=0):
         """

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -1,6 +1,7 @@
 #include "libsbmlnetwork_c_api.h"
-#include "../libsbmlnetwork_common.h"
-#include "../libsbmlnetwork_layout.h"
+#include "../libsbmlnetwork_sbmldocument.h"
+#include "../libsbmlnetwork_sbmldocument_layout.h"
+#include "../libsbmlnetwork_sbmldocument_render.h"
 #include "../libsbmlnetwork_layout_helpers.h"
 #include "../libsbmlnetwork_render_helpers.h"
 #include "../colors/libsbmlnetwork_colors.h"
@@ -14,8 +15,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return strdup(getLibraryVersion().c_str());
     }
 
-    const char* c_api_getCurrentDirectoryOfLibrary() {
-        return strdup(getCurrentDirectoryOfLibrary().c_str());
+    const char* c_api_getCurrentDirectoryOfLibrary() {return strdup(getCurrentDirectoryOfLibrary().c_str());
     }
 
     SBMLDocument* c_api_readSBML(const char* sbml) {
@@ -968,12 +968,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxX(document, renderIndex, id, x);
     }
 
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
+    }
+
     const double c_api_getLineEndingBoundingBoxY(SBMLDocument* document, const char* id, int renderIndex) {
         return getLineEndingBoundingBoxY(document, renderIndex, id);
     }
 
     int c_api_setLineEndingBoundingBoxY(SBMLDocument* document, const char* id, const double y, int renderIndex) {
         return setLineEndingBoundingBoxY(document, renderIndex, id, y);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
     }
 
     const double c_api_getLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -984,12 +1000,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxWidth(document, renderIndex, id, width);
     }
 
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
+    }
+
     const double c_api_getLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, int renderIndex) {
         return getLineEndingBoundingBoxHeight(document, renderIndex, id);
     }
 
     int c_api_setLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, const double height, int renderIndex) {
         return setLineEndingBoundingBoxHeight(document, renderIndex, id, height);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
     }
 
     bool c_api_isSetLineEndingBorderColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1004,6 +1036,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeColor(document, renderIndex, id, borderColor);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
+    }
+
     bool c_api_isSetLineEndingBorderWidth(SBMLDocument* document, const char* id, int renderIndex) {
         return isSetLineEndingStrokeWidth(document, renderIndex, id);
     }
@@ -1016,7 +1060,19 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeWidth(document, renderIndex, id, borderWidth);
     }
 
-    int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex) {
+    bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
+    }
+
+    const int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex) {
         return getNumLineEndingStrokeDashes(document, renderIndex, id);
     }
 
@@ -1026,6 +1082,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingNthBorderDash(SBMLDocument* document, const char* id, const int dash, int dashIndex, int renderIndex) {
         return setLineEndingStrokeDash(document, renderIndex, id, dashIndex, dash);
+    }
+
+    const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumSpeciesReferenceLineEndingStrokeDashes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
     }
 
     bool c_api_isSetLineEndingFillColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1040,6 +1108,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillColor(document, renderIndex, id, fillColor);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    }
+
+    int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
+    }
+
     bool c_api_isSetLineEndingFillRule(SBMLDocument* document, const char* id, int renderIndex) {
         return isSetLineEndingFillRule(document, renderIndex, id);
     }
@@ -1052,32 +1132,72 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillRule(document, renderIndex, id, fillRule);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    }
+
+    const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    }
+
+    int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
+    }
+
     const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex) {
         return getNumLineEndingGeometricShapes(document, renderIndex, id);
+    }
+
+    const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumSpeciesReferenceLineEndingGeometricShapes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
     bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRectangle(document, renderIndex, id, geometricShapeIndex);
     }
 
+    bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingRectangle(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
     bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingEllipse(document, renderIndex, id, geometricShapeIndex);
+    }
+
+    bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingEllipse(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingPolygon(document, renderIndex, id, geometricShapeIndex);
     }
 
+    bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingPolygon(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
     bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingImage(document, renderIndex, id, geometricShapeIndex);
+    }
+
+    bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingImage(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRenderCurve(document, renderIndex, id, geometricShapeIndex);
     }
 
+    bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingRenderCurve(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
     bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingText(document, renderIndex, id, geometricShapeIndex);
+    }
+
+    bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingText(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isSetLineEndingGeometricShapeX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1092,6 +1212,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeXAsDouble(document, renderIndex, id, geometricShapeIndex, x);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeY(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1102,6 +1234,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeYAsDouble(document, renderIndex, id, geometricShapeIndex, y);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1116,6 +1260,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeWidthAsDouble(document, renderIndex, id, geometricShapeIndex, width);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeHeight(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1126,6 +1282,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeHeightAsDouble(document, renderIndex, id, geometricShapeIndex, height);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1140,6 +1308,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRatio(document, renderIndex, id, geometricShapeIndex, ratio);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeCornerCurvatureRadiusX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1150,6 +1330,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double borderRadiusX, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusX);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1164,6 +1356,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusY);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeCenterX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1174,6 +1378,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, const double centerX, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeCenterXAsDouble(document, id, geometricShapeIndex, centerX);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1188,6 +1404,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCenterYAsDouble(document, id, geometricShapeIndex, centerY);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeRadiusX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1198,6 +1426,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double radiusX, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeRadiusXAsDouble(document, id, geometricShapeIndex, radiusX);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1212,12 +1452,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRadiusYAsDouble(document, id, geometricShapeIndex, radiusY);
     }
 
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
+    }
+
     int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeNumElements(document, renderIndex, id, geometricShapeIndex);
     }
 
+    int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
     bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return isLineEndingGeometricShapeElementCubicBezier(document, renderIndex, id, geometricShapeIndex, segmentIndex);
+    }
+
+    bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
     const double c_api_getLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1228,12 +1488,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeElementXAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeElementYAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
 
     int c_api_setLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeElementYAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1244,12 +1520,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint1XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeBasePoint1YAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
 
     int c_api_setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeBasePoint1YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1260,12 +1552,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint2XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeBasePoint2YAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
 
     int c_api_setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeBasePoint2YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
+    }
+
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1278,6 +1586,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, const char* href, int geometricShapeIndex, int renderIndex) {
         return setLineEndingGeometricShapeHref(document, renderIndex, id, geometricShapeIndex, href);
+    }
+
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    }
+
+    const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return strdup(getSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex).c_str());
+    }
+
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
     }
 
     bool c_api_isSetBorderColor(SBMLDocument* document, const char* id, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -70,10 +70,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_distribute(SBMLDocument* document, const char **nodeIds, const int nodesSize,  const char* direction, const double spacing) {
-        std::set<std::string> nodeIdsSet = std::set<std::string>();
+        std::set<std::pair<std::string, unsigned int>> nodeIdsSet = std::set<std::pair<std::string, unsigned int>>();
         if (nodeIds) {
             for (int i = 0; i < nodesSize; i++)
-                nodeIdsSet.insert(nodeIds[i]);
+                nodeIdsSet.insert(std::make_pair(nodeIds[i], i));
         }
         return distribute(document, nodeIdsSet, direction, spacing);
     }

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -841,7 +841,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setLinearGradientX1(SBMLDocument* document, const char* id, const double x1, int renderIndex) {
-        return setLinearGradientX1(document, renderIndex, id, x1);
+        return setLinearGradientX1AsDouble(document, renderIndex, id, x1);
     }
 
     bool c_api_isSetLinearGradientY1(SBMLDocument* document, const char* id, int renderIndex) {
@@ -853,7 +853,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setLinearGradientY1(SBMLDocument* document, const char* id, const double y1, int renderIndex) {
-        return setLinearGradientY1(document, renderIndex, id, y1);
+        return setLinearGradientY1AsDouble(document, renderIndex, id, y1);
     }
 
     bool c_api_isSetLinearGradientX2(SBMLDocument* document, const char* id, int renderIndex) {
@@ -865,7 +865,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setLinearGradientX2(SBMLDocument* document, const char* id, const double x2, int renderIndex) {
-        return setLinearGradientX2(document, renderIndex, id, x2);
+        return setLinearGradientX2AsDouble(document, renderIndex, id, x2);
     }
 
     bool c_api_isSetLinearGradientY2(SBMLDocument* document, const char* id, int renderIndex) {
@@ -877,7 +877,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setLinearGradientY2(SBMLDocument* document, const char* id, const double y2, int renderIndex) {
-        return setLinearGradientY2(document, renderIndex, id, y2);
+        return setLinearGradientY2AsDouble(document, renderIndex, id, y2);
     }
 
     bool c_api_isSetRadialGradientCenterX(SBMLDocument* document, const char* id, int renderIndex) {
@@ -889,7 +889,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setRadialGradientCenterX(SBMLDocument* document, const char* id, const double cx, int renderIndex) {
-        return setRadialGradientCx(document, renderIndex, id, cx);
+        return setRadialGradientCxAsDouble(document, renderIndex, id, cx);
     }
 
     bool c_api_isSetRadialGradientCenterY(SBMLDocument* document, const char* id, int renderIndex) {
@@ -901,7 +901,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setRadialGradientCenterY(SBMLDocument* document, const char* id, const double cy, int renderIndex) {
-        return setRadialGradientCy(document, renderIndex, id, cy);
+        return setRadialGradientCyAsDouble(document, renderIndex, id, cy);
     }
 
     bool c_api_isSetRadialGradientRadius(SBMLDocument* document, const char* id, int renderIndex) {
@@ -913,7 +913,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setRadialGradientRadius(SBMLDocument* document, const char* id, const double r, int renderIndex) {
-        return setRadialGradientR(document, renderIndex, id, r);
+        return setRadialGradientRAsDouble(document, renderIndex, id, r);
     }
 
     bool c_api_isSetRadialGradientFocalX(SBMLDocument* document, const char* id, int renderIndex) {
@@ -925,7 +925,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setRadialGradientFocalX(SBMLDocument* document, const char* id, const double fx, int renderIndex) {
-        return setRadialGradientFx(document, renderIndex, id, fx);
+        return setRadialGradientFxAsDouble(document, renderIndex, id, fx);
     }
 
     bool c_api_isSetRadialGradientFocalY(SBMLDocument* document, const char* id, int renderIndex) {
@@ -937,7 +937,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     }
 
     int c_api_setRadialGradientFocalY(SBMLDocument* document, const char* id, const double fy, int renderIndex) {
-        return setRadialGradientFy(document, renderIndex, id, fy);
+        return setRadialGradientFyAsDouble(document, renderIndex, id, fy);
     }
 
     const int c_api_getNumLineEndings(SBMLDocument* document, int renderIndex) {
@@ -1108,6 +1108,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillColor(document, renderIndex, id, fillColor);
     }
 
+    int c_api_setLineEndingFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int renderIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setLineEndingFillColorAsGradient(document, renderIndex, id, gradientType, stopsVector);
+    }
+
     bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         return isSetSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
@@ -1118,6 +1126,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         return setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
+    }
+
+    int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
     }
 
     bool c_api_isSetLineEndingFillRule(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1778,12 +1794,28 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setFillColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), fillColor);
     }
 
+    int c_api_setFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int graphicalObjectIndex, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setFillColorAsGradient(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), gradientType, stopsVector);
+    }
+
     const char* c_api_getCompartmentsFillColor(SBMLDocument* document) {
         return strdup(getCompartmentFillColor(document).c_str());
     }
 
     int c_api_setCompartmentsFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex) {
         return setCompartmentFillColor(document, layoutIndex, fillColor);
+    }
+
+    int c_api_setCompartmentsFillColorAsGradient(SBMLDocument* document, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setCompartmentFillColorAsGradient(document, layoutIndex, gradientType, stopsVector);
     }
 
     const char* c_api_getSpeciesFillColor(SBMLDocument* document) {
@@ -1794,6 +1826,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesFillColor(document, layoutIndex, fillColor);
     }
 
+    int c_api_setSpeciesFillColorAsGradient(SBMLDocument* document, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setSpeciesFillColorAsGradient(document, layoutIndex, gradientType, stopsVector);
+    }
+
     const char* c_api_getReactionsFillColor(SBMLDocument* document) {
         return strdup(getReactionFillColor(document).c_str());
     }
@@ -1802,12 +1842,36 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setReactionFillColor(document, layoutIndex, fillColor);
     }
 
+    int c_api_setReactionsFillColorAsGradient(SBMLDocument* document, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setReactionFillColorAsGradient(document, layoutIndex, gradientType, stopsVector);
+    }
+
     int c_api_setLineEndingsFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex) {
         return setLineEndingFillColor(document, layoutIndex, fillColor);
     }
 
+    int c_api_setLineEndingsFillColorAsGradient(SBMLDocument* document, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setLineEndingFillColorAsGradient(document, layoutIndex, gradientType, stopsVector);
+    }
+
     int c_api_setFillColors(SBMLDocument* document, const char* fillColor, int layoutIndex) {
         return setFillColor(document, layoutIndex, fillColor);
+    }
+
+    int c_api_setFillColorsAsGradient(SBMLDocument* document, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setFillColorAsGradient(document, layoutIndex, gradientType, stopsVector);
     }
 
     bool c_api_isSetFillRule(SBMLDocument* document, const char* id, int graphicalObjectIndex, int layoutIndex) {
@@ -2268,6 +2332,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setGeometricShapeFillColor(SBMLDocument* document, const char* id, const char* fillColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
         return setGeometricShapeFillColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex, fillColor);
+    }
+
+    int c_api_setGeometricShapeFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setGeometricShapeFillColorAsGradient(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex, gradientType, stopsVector);
     }
 
     bool c_api_isSetGeometricShapeX(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -1914,6 +1914,42 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return isText(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
     }
 
+    bool c_api_isSetGeometricShapeBorderColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return isSetGeometricShapeStrokeColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
+    const char* c_api_getGeometricShapeBorderColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return strdup(getGeometricShapeStrokeColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex).c_str());
+    }
+
+    int c_api_setGeometricShapeBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return setGeometricShapeStrokeColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex, borderColor);
+    }
+
+    bool c_api_isSetGeometricShapeBorderWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return isSetGeometricShapeStrokeWidth(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
+    const double c_api_getGeometricShapeBorderWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return getGeometricShapeStrokeWidth(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
+    int c_api_setGeometricShapeBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return setGeometricShapeStrokeWidth(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex, borderWidth);
+    }
+
+    bool c_api_isSetGeometricShapeFillColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return isSetGeometricShapeFillColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
+    }
+
+    const char* c_api_getGeometricShapeFillColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return strdup(getGeometricShapeFillColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex).c_str());
+    }
+
+    int c_api_setGeometricShapeFillColor(SBMLDocument* document, const char* id, const char* fillColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
+        return setGeometricShapeFillColor(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex, fillColor);
+    }
+
     bool c_api_isSetGeometricShapeX(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex) {
         return isSetGeometricShapeX(document, getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), geometricShapeIndex);
     }

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -56,8 +56,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return autolayout(document, maxNumConnectedEdges, useNameAsTextLabel, resetLockedNodes, lockedNodeIdsSet);
     }
 
-    int c_api_autorender(SBMLDocument *document) {
-        return autorender(document);
+    int c_api_autorender(SBMLDocument *document, const int maxNumConnectedEdges) {
+        return autorender(document, maxNumConnectedEdges);
     }
 
     int c_api_align(SBMLDocument* document, const char **nodeIds, const int nodesSize,  const char* alignment, bool ignoreLockedNodes) {

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -976,6 +976,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
     }
 
+    int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, x);
+    }
+
     const double c_api_getLineEndingBoundingBoxY(SBMLDocument* document, const char* id, int renderIndex) {
         return getLineEndingBoundingBoxY(document, renderIndex, id);
     }
@@ -990,6 +994,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         return setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
+    }
+
+    int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, y);
     }
 
     const double c_api_getLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1008,6 +1016,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
     }
 
+    int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, width);
+    }
+
     const double c_api_getLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, int renderIndex) {
         return getLineEndingBoundingBoxHeight(document, renderIndex, id);
     }
@@ -1022,6 +1034,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         return setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
+    }
+
+    int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, height);
     }
 
     bool c_api_isSetLineEndingBorderColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1048,6 +1064,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
     }
 
+    int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, borderColor);
+    }
+
     bool c_api_isSetLineEndingBorderWidth(SBMLDocument* document, const char* id, int renderIndex) {
         return isSetLineEndingStrokeWidth(document, renderIndex, id);
     }
@@ -1072,6 +1092,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
     }
 
+    int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, borderWidth);
+    }
+
     const int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex) {
         return getNumLineEndingStrokeDashes(document, renderIndex, id);
     }
@@ -1094,6 +1118,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
         return setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
+    }
+
+    int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int dashIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, dashIndex, dash);
     }
 
     bool c_api_isSetLineEndingFillColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1136,6 +1164,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
     }
 
+    int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, fillColor);
+    }
+
+    int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int layoutIndex) {
+        std::vector<std::pair<std::string, double>> stopsVector;
+        for (int i = 0; i < stopsSize; i++)
+            stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
+
+        return setReactionLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, gradientType, stopsVector);
+    }
+
     bool c_api_isSetLineEndingFillRule(SBMLDocument* document, const char* id, int renderIndex) {
         return isSetLineEndingFillRule(document, renderIndex, id);
     }
@@ -1158,6 +1198,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         return setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
+    }
+
+    int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, fillRule);
     }
 
     const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1240,6 +1284,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, x);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeY(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1262,6 +1310,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1288,6 +1340,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, width);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeHeight(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1310,6 +1366,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, height);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1336,6 +1396,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, ratio);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeCornerCurvatureRadiusX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1358,6 +1422,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, borderRadiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1384,6 +1452,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, borderRadiusY);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeCenterX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1406,6 +1478,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, centerX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1432,6 +1508,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, centerY);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeRadiusX(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1456,6 +1536,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, radiusX);
+    }
+
     bool c_api_isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isSetLineEndingGeometricShapeRadiusY(document, renderIndex, id, geometricShapeIndex);
     }
@@ -1478,6 +1562,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, radiusY);
     }
 
     int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1512,6 +1600,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeElementYAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
@@ -1526,6 +1618,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1544,6 +1640,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeBasePoint1YAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
@@ -1558,6 +1658,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1576,6 +1680,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
+    int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    }
+
     const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeBasePoint2YAsDouble(document, id, geometricShapeIndex, segmentIndex);
     }
@@ -1590,6 +1698,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1614,6 +1726,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
         return setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
+    }
+
+    int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, geometricShapeIndex, href);
     }
 
     bool c_api_isSetBorderColor(SBMLDocument* document, const char* id, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -968,12 +968,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxX(document, renderIndex, id, x);
     }
 
-    const double c_api_getReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getReactionLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
     }
 
     const double c_api_getLineEndingBoundingBoxY(SBMLDocument* document, const char* id, int renderIndex) {
@@ -984,12 +984,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxY(document, renderIndex, id, y);
     }
 
-    const double c_api_getReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getReactionLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
     }
 
     const double c_api_getLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1000,12 +1000,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxWidth(document, renderIndex, id, width);
     }
 
-    const double c_api_getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getReactionLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
     }
 
     const double c_api_getLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1016,12 +1016,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxHeight(document, renderIndex, id, height);
     }
 
-    const double c_api_getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getReactionLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
+    int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
     }
 
     bool c_api_isSetLineEndingBorderColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1036,16 +1036,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeColor(document, renderIndex, id, borderColor);
     }
 
-    bool c_api_isSetReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
+    int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
     }
 
     bool c_api_isSetLineEndingBorderWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1060,16 +1060,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeWidth(document, renderIndex, id, borderWidth);
     }
 
-    bool c_api_isSetReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const double c_api_getReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
+    int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
     }
 
     const int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1084,16 +1084,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeDash(document, renderIndex, id, dashIndex, dash);
     }
 
-    const int c_api_getNumReactionLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getNumReactionLineEndingStrokeDashes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumSpeciesReferenceLineEndingStrokeDashes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const int c_api_getReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
-        return getReactionLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex);
+    const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return getSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex);
     }
 
-    int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
-        return setReactionLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
+    int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
     }
 
     bool c_api_isSetLineEndingFillColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1116,24 +1116,24 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillColorAsGradient(document, renderIndex, id, gradientType, stopsVector);
     }
 
-    bool c_api_isSetReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
+    int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
     }
 
-    int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+    int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         std::vector<std::pair<std::string, double>> stopsVector;
         for (int i = 0; i < stopsSize; i++)
             stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
 
-        return setReactionLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
+        return setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
     }
 
     bool c_api_isSetLineEndingFillRule(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1148,72 +1148,72 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillRule(document, renderIndex, id, fillRule);
     }
 
-    bool c_api_isSetReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
+    int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
     }
 
     const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex) {
         return getNumLineEndingGeometricShapes(document, renderIndex, id);
     }
 
-    const int c_api_getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getNumReactionLineEndingGeometricShapes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumSpeciesReferenceLineEndingGeometricShapes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
     bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRectangle(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingRectangle(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingRectangle(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingEllipse(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingEllipse(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingEllipse(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingPolygon(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingPolygon(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingPolygon(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingImage(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingImage(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingImage(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRenderCurve(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingRenderCurve(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingRenderCurve(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingText(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isReactionLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isReactionLineEndingText(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingText(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isSetLineEndingGeometricShapeX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1228,16 +1228,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeXAsDouble(document, renderIndex, id, geometricShapeIndex, x);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
     }
 
     bool c_api_isSetLineEndingGeometricShapeY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1252,16 +1252,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeYAsDouble(document, renderIndex, id, geometricShapeIndex, y);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1276,16 +1276,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeWidthAsDouble(document, renderIndex, id, geometricShapeIndex, width);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1300,16 +1300,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeHeightAsDouble(document, renderIndex, id, geometricShapeIndex, height);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1324,16 +1324,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRatio(document, renderIndex, id, geometricShapeIndex, ratio);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1348,16 +1348,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusX);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1372,16 +1372,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusY);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1396,16 +1396,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCenterXAsDouble(document, id, geometricShapeIndex, centerX);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1420,16 +1420,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCenterYAsDouble(document, id, geometricShapeIndex, centerY);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1444,16 +1444,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRadiusXAsDouble(document, id, geometricShapeIndex, radiusX);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1468,32 +1468,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRadiusYAsDouble(document, id, geometricShapeIndex, radiusY);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
     }
 
     int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeNumElements(document, renderIndex, id, geometricShapeIndex);
     }
 
-    int c_api_getReactionLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeNumElements(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return isLineEndingGeometricShapeElementCubicBezier(document, renderIndex, id, geometricShapeIndex, segmentIndex);
     }
 
-    bool c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return isReactionLineEndingGeometricShapeElementCubicBezier(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
     const double c_api_getLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1504,12 +1504,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeElementXAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1520,12 +1520,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeElementYAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1536,12 +1536,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint1XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1552,12 +1552,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint1YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1568,12 +1568,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint2XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1584,12 +1584,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint2YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1604,16 +1604,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeHref(document, renderIndex, id, geometricShapeIndex, href);
     }
 
-    bool c_api_isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const char* c_api_getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return strdup(getReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex).c_str());
+    const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return strdup(getSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex).c_str());
     }
 
-    int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
+    int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
     }
 
     bool c_api_isSetBorderColor(SBMLDocument* document, const char* id, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -968,12 +968,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxX(document, renderIndex, id, x);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getReactionLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
+    int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, x);
     }
 
     const double c_api_getLineEndingBoundingBoxY(SBMLDocument* document, const char* id, int renderIndex) {
@@ -984,12 +984,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxY(document, renderIndex, id, y);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getReactionLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
+    int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, y);
     }
 
     const double c_api_getLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1000,12 +1000,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxWidth(document, renderIndex, id, width);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getReactionLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
+    int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, width);
     }
 
     const double c_api_getLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1016,12 +1016,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingBoundingBoxHeight(document, renderIndex, id, height);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getReactionLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
+    int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, height);
     }
 
     bool c_api_isSetLineEndingBorderColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1036,16 +1036,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeColor(document, renderIndex, id, borderColor);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
+    int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderColor);
     }
 
     bool c_api_isSetLineEndingBorderWidth(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1060,16 +1060,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeWidth(document, renderIndex, id, borderWidth);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const double c_api_getReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
+    int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, borderWidth);
     }
 
     const int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1084,16 +1084,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingStrokeDash(document, renderIndex, id, dashIndex, dash);
     }
 
-    const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getNumSpeciesReferenceLineEndingStrokeDashes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const int c_api_getNumReactionLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumReactionLineEndingStrokeDashes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
-        return getSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex);
+    const int c_api_getReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return getReactionLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
+    int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int dashIndex, int layoutIndex) {
+        return setReactionLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, dashIndex, dash);
     }
 
     bool c_api_isSetLineEndingFillColor(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1116,24 +1116,24 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillColorAsGradient(document, renderIndex, id, gradientType, stopsVector);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
+    int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillColor);
     }
 
-    int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+    int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType, const char** stopColors, const double* stopOffsets, const int stopsSize, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
         std::vector<std::pair<std::string, double>> stopsVector;
         for (int i = 0; i < stopsSize; i++)
             stopsVector.push_back(std::make_pair(stopColors[i], stopOffsets[i]));
 
-        return setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
+        return setReactionLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, gradientType, stopsVector);
     }
 
     bool c_api_isSetLineEndingFillRule(SBMLDocument* document, const char* id, int renderIndex) {
@@ -1148,72 +1148,72 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingFillRule(document, renderIndex, id, fillRule);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return isSetSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    bool c_api_isSetReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return isSetReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
-    const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return strdup(getSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
+    const char* c_api_getReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return strdup(getReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex).c_str());
     }
 
-    int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
+    int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return setReactionLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, fillRule);
     }
 
     const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex) {
         return getNumLineEndingGeometricShapes(document, renderIndex, id);
     }
 
-    const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
-        return getNumSpeciesReferenceLineEndingGeometricShapes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
+    const int c_api_getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex) {
+        return getNumReactionLineEndingGeometricShapes(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex);
     }
 
     bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRectangle(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingRectangle(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingRectangle(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingEllipse(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingEllipse(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingEllipse(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingPolygon(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingPolygon(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingPolygon(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingImage(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingImage(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingImage(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingRenderCurve(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingRenderCurve(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingRenderCurve(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return isLineEndingText(document, renderIndex, id, geometricShapeIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingText(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isReactionLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isReactionLineEndingText(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isSetLineEndingGeometricShapeX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1228,16 +1228,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeXAsDouble(document, renderIndex, id, geometricShapeIndex, x);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
+    int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, x);
     }
 
     bool c_api_isSetLineEndingGeometricShapeY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1252,16 +1252,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeYAsDouble(document, renderIndex, id, geometricShapeIndex, y);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
+    int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1276,16 +1276,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeWidthAsDouble(document, renderIndex, id, geometricShapeIndex, width);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
+    int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, width);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1300,16 +1300,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeHeightAsDouble(document, renderIndex, id, geometricShapeIndex, height);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
+    int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, height);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1324,16 +1324,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRatio(document, renderIndex, id, geometricShapeIndex, ratio);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
+    int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, ratio);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1348,16 +1348,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusX);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
+    int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double borderRadiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1372,16 +1372,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, renderIndex, id, geometricShapeIndex, borderRadiusY);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
+    int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double borderRadiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, borderRadiusY);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1396,16 +1396,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCenterXAsDouble(document, id, geometricShapeIndex, centerX);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
+    int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double centerX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1420,16 +1420,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeCenterYAsDouble(document, id, geometricShapeIndex, centerY);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
+    int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double centerY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, centerY);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1444,16 +1444,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRadiusXAsDouble(document, id, geometricShapeIndex, radiusX);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
+    int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double radiusX, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusX);
     }
 
     bool c_api_isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1468,32 +1468,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeRadiusYAsDouble(document, id, geometricShapeIndex, radiusY);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    const double c_api_getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
+    int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double radiusY, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, radiusY);
     }
 
     int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
         return getLineEndingGeometricShapeNumElements(document, renderIndex, id, geometricShapeIndex);
     }
 
-    int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    int c_api_getReactionLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeNumElements(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
     bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
         return isLineEndingGeometricShapeElementCubicBezier(document, renderIndex, id, geometricShapeIndex, segmentIndex);
     }
 
-    bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    bool c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return isReactionLineEndingGeometricShapeElementCubicBezier(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
     const double c_api_getLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1504,12 +1504,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeElementXAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1520,12 +1520,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeElementYAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1536,12 +1536,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint1XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1552,12 +1552,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint1YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1568,12 +1568,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint2XAsDouble(document, id, geometricShapeIndex, segmentIndex, x);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
+    int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, x);
     }
 
     const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex, int renderIndex) {
@@ -1584,12 +1584,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeBasePoint2YAsDouble(document, id, geometricShapeIndex, segmentIndex, y);
     }
 
-    const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
+    const double c_api_getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return getReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex);
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
+    int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int segmentIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, segmentIndex, y);
     }
 
     bool c_api_isSetLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, int geometricShapeIndex, int renderIndex) {
@@ -1604,16 +1604,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setLineEndingGeometricShapeHref(document, renderIndex, id, geometricShapeIndex, href);
     }
 
-    bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
+    bool c_api_isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return isSetReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex);
     }
 
-    const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return strdup(getSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex).c_str());
+    const char* c_api_getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return strdup(getReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex).c_str());
     }
 
-    int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
-        return setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
+    int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex, int speciesReferenceGlyphIndex, int layoutIndex, int geometricShapeIndex) {
+        return setReactionLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceGlyphIndex, geometricShapeIndex, href);
     }
 
     bool c_api_isSetBorderColor(SBMLDocument* document, const char* id, int graphicalObjectIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -1832,9 +1832,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxX(SBMLDocument* document, const char* id, const double x, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1851,9 +1851,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxY(SBMLDocument* document, const char* id, const double y, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1870,9 +1870,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, const double width, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1889,9 +1889,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, const double height, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1916,11 +1916,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1945,11 +1945,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1971,11 +1971,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingNthBorderDash(SBMLDocument* document, const char* id, const int dash, int borderDashIndex, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getNumReactionLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2002,13 +2002,13 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2033,11 +2033,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillRule(SBMLDocument* document, const char* id, const char* fillRule, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns number of Transformation2D objects in the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2046,7 +2046,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the number of Transformation2D objects in the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
     /// @param document a pointer to the SBMLDocument object.
@@ -2057,7 +2057,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Rectangle or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
     /// @param document a pointer to the SBMLDocument object.
@@ -2068,7 +2068,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Ellipse or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
     /// @param document a pointer to the SBMLDocument object.
@@ -2079,7 +2079,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Polygon or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
     /// @param document a pointer to the SBMLDocument object.
@@ -2090,7 +2090,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Image or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
     /// @param document a pointer to the SBMLDocument object.
@@ -2101,7 +2101,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type RenderCurve or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
     /// @param document a pointer to the SBMLDocument object.
@@ -2112,7 +2112,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Text or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2140,11 +2140,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeX(SBMLDocument* document, const char* id, const double x, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2172,11 +2172,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2204,11 +2204,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, const double width, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2236,11 +2236,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2268,11 +2268,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, const double ratio, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2300,11 +2300,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2332,11 +2332,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2364,11 +2364,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, const double cx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2396,11 +2396,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, const double cy, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2428,11 +2428,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object
@@ -2460,11 +2460,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the number of elements of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2474,12 +2474,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the number of elements of the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_getReactionLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "type" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set to "cubicBezier".
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2500,9 +2500,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2523,9 +2523,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2546,9 +2546,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2569,9 +2569,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2592,9 +2592,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2615,9 +2615,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "href" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2645,11 +2645,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, const char* href, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is set.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -1,9 +1,13 @@
 #ifndef __LIBSBMLNETWORK_C_API_H_
 #define __LIBSBMLNETWORK_C_API_H_
 
-#include "../libsbmlnetwork_sbmldocument.h"
-#include "../libsbmlnetwork_sbmldocument_layout.h"
-#include "../libsbmlnetwork_sbmldocument_render.h"
+#include "../libsbmlnetwork_common.h"
+
+#ifndef SWIG
+#include "sbml/SBMLTypes.h"
+#endif
+
+using namespace libsbml;
 
 #ifdef __cplusplus
 extern "C" {
@@ -514,7 +518,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param x the value to be set as "x" attribute of the start point of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, const char* reactionId, double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the start point of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -538,7 +542,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param y the value to be set as "y" attribute of the start point of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, const char* reactionId, double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the end point of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -562,7 +566,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param x the value to be set as "x" attribute of the end point of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentEndPointX(SBMLDocument* document, const char* reactionId, double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentEndPointX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the end point of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -586,7 +590,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param y the value to be set as "y" attribute of the end point of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, const char* reactionId, double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 1 of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -610,7 +614,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param x the value to be set as "x" attribute of the base point 1 of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, const char* reactionId, double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 1 of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -634,7 +638,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param y the value to be set as "y" attribute of the base point 1 of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, const char* reactionId, double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 2 of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -658,7 +662,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param x the value to be set as "x" attribute of the base point 2 of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, const char* reactionId, double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 2 of the CubicBezier object with the given index of the Curve of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document.
@@ -682,7 +686,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @param y the value to be set as "y" attribute of the base point 2 of the CubicBezier object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, const char* reactionId, double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int curveSegmentIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the SpeciesReferenceGlyph object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document is set.
@@ -1818,7 +1822,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "x" attribute of the bounding box of the LineEnding object, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingBoundingBoxX(SBMLDocument* document, const char* id, int renderIndex = 0);
-
+    
     /// @brief Sets the value of the "x" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1826,6 +1830,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxX(SBMLDocument* document, const char* id, const double x, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1842,6 +1850,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxY(SBMLDocument* document, const char* id, const double y, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1857,6 +1869,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, const double width, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1871,6 +1887,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, const double height, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1895,6 +1915,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1918,11 +1944,17 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
     /// @param renderIndex the index number of the RenderInformationBase object.
-    LIBSBMLNETWORK_EXTERN int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumLineEndingBorderDashes(SBMLDocument* document, const char* id, int renderIndex = 0);
 
     /// @brief Returns the value of the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1937,6 +1969,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param numBorderDashes the number of elements in the borderDashes array.
     /// @param renderIndex the index number of the RenderInformationBase object.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingNthBorderDash(SBMLDocument* document, const char* id, const int dash, int borderDashIndex, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1961,6 +1999,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColor(SBMLDocument* document, const char* id, const char* fillColor, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1984,12 +2028,20 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillRule(SBMLDocument* document, const char* id, const char* fillRule, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns number of Transformation2D objects in the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the number of Transformation2D objects in the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
     /// @param document a pointer to the SBMLDocument object.
@@ -2000,6 +2052,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Rectangle or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2008,6 +2062,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Ellipse, @c false if either the Transformation2D
     /// object is not of type Ellipse or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
     /// @param document a pointer to the SBMLDocument object.
@@ -2018,6 +2074,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Polygon or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2026,6 +2084,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Image, @c false if either the Transformation2D
     /// object is not of type Image or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
     /// @param document a pointer to the SBMLDocument object.
@@ -2036,6 +2096,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type RenderCurve or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2044,6 +2106,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Text, @c false if either the Transformation2D
     /// object is not of type Text or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2071,6 +2135,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeX(SBMLDocument* document, const char* id, const double x, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2096,6 +2166,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2123,6 +2199,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, const double width, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2148,6 +2230,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2175,6 +2263,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, const double ratio, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2200,6 +2294,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2227,6 +2327,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2252,6 +2358,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, const double cx, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2279,6 +2391,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, const double cy, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2304,6 +2422,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object
@@ -2331,6 +2455,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Returns the number of elements of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2339,8 +2469,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the number of elements of the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "type" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set to "cubicBezier".
-    LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2349,7 +2483,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2359,7 +2493,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, const double x, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2368,7 +2506,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2378,7 +2516,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2387,7 +2529,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "x" attribute of the base point 1 of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "x" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2397,7 +2539,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, const double x, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2406,7 +2552,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "y" attribute of the base point 1 of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "y" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2416,7 +2562,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2425,7 +2575,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "x" attribute of the base point 2 of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "x" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2435,7 +2585,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, const double x, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2444,7 +2598,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return the "y" attribute of the base point 2 of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL
-    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
     /// @brief Sets the value of the "y" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2454,7 +2608,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex, int geometricShapeIndex = 0, int renderIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "href" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2481,6 +2639,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, const char* href, int geometricShapeIndex = 0, int renderIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is set.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -3451,6 +3451,90 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// it is not of type Text or is or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isText(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return @c true if the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set,
+    bool c_api_isSetGeometricShapeBorderColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Returns the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+    const char* c_api_getGeometricShapeBorderColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param borderColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return integer value indicating success/failure of the function.
+    int c_api_setGeometricShapeBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return @c true if the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+    bool c_api_isSetGeometricShapeBorderWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Returns the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c 0.0 if the object is @c NULL.
+    const double c_api_getGeometricShapeBorderWidth(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param borderWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return integer value indicating success/failure of the function.
+    int c_api_setGeometricShapeBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return @c true if the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+    bool c_api_isSetGeometricShapeFillColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Returns the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+    const char* c_api_getGeometricShapeFillColor(SBMLDocument* document, const char* id, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of a model entity.
+    /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @param graphicalObjectIndex an int representing the index of the GraphicalObject to retrieve.
+    /// @param layoutIndex an int representing the index of the Layout to retrieve.
+    /// @return integer value indicating success/failure of the function.
+    int c_api_setGeometricShapeFillColor(SBMLDocument* document, const char* id, const char* fillColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -2000,11 +2000,15 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColor(SBMLDocument* document, const char* id, const char* fillColor, int renderIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int renderIndex = 0);
+
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2865,6 +2869,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// attribute is not set or the object is @c NULL .
     LIBSBMLNETWORK_EXTERN bool c_api_isSetFillColor(SBMLDocument* document, const char* id, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
@@ -2891,6 +2897,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFillColorAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
+
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFillColor(SBMLDocument* document);
 
     /// @brief Sets the value of the "fill" attribute of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
@@ -2899,6 +2907,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFillColorAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFillColor(SBMLDocument* document);
 
@@ -2909,6 +2919,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionsFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionsFillColorAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
+
     /// @brief Sets the value of the "fill" attribute of the RenderGroup of all LineEndings objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the Style for these GraphicalObject objects.
@@ -2916,12 +2928,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingsFillColor(SBMLDocument* document, const char* fillColor, int layoutIndex);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setLineEndingsFillColorAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
+
     /// @brief Sets the value of the "fill" attribute of the RenderGroup of the Style of all GraphicalObjects objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFillColors(SBMLDocument* document, const char* fillColor, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setFillColorsAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
     /// @param document a pointer to the SBMLDocument object.
@@ -3699,6 +3715,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     int c_api_setGeometricShapeFillColor(SBMLDocument* document, const char* id, const char* fillColor, int geometricShapeIndex, int graphicalObjectIndex, int layoutIndex);
+
+    int c_api_setGeometricShapeFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -1832,9 +1832,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxX(SBMLDocument* document, const char* id, const double x, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1851,9 +1851,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxY(SBMLDocument* document, const char* id, const double y, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1870,9 +1870,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, const double width, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1889,9 +1889,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, const double height, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1916,11 +1916,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1945,11 +1945,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1971,11 +1971,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingNthBorderDash(SBMLDocument* document, const char* id, const int dash, int borderDashIndex, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumReactionLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2002,13 +2002,13 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2033,11 +2033,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillRule(SBMLDocument* document, const char* id, const char* fillRule, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns number of Transformation2D objects in the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2046,7 +2046,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the number of Transformation2D objects in the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const int c_api_getNumLineEndingGeometricShapes(SBMLDocument* document, const char* id, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
     /// @param document a pointer to the SBMLDocument object.
@@ -2057,7 +2057,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Rectangle or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
     /// @param document a pointer to the SBMLDocument object.
@@ -2068,7 +2068,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Ellipse or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
     /// @param document a pointer to the SBMLDocument object.
@@ -2079,7 +2079,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Polygon or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
     /// @param document a pointer to the SBMLDocument object.
@@ -2090,7 +2090,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Image or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
     /// @param document a pointer to the SBMLDocument object.
@@ -2101,7 +2101,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type RenderCurve or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
     /// @param document a pointer to the SBMLDocument object.
@@ -2112,7 +2112,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Text or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2140,11 +2140,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeX(SBMLDocument* document, const char* id, const double x, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2172,11 +2172,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2204,11 +2204,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, const double width, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2236,11 +2236,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2268,11 +2268,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, const double ratio, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2300,11 +2300,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2332,11 +2332,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2364,11 +2364,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, const double cx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2396,11 +2396,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, const double cy, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2428,11 +2428,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object
@@ -2460,11 +2460,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the number of elements of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2474,12 +2474,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the number of elements of the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN int c_api_getLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_getSpeciesReferenceLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_getReactionLineEndingGeometricShapeNumSegments(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "type" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set to "cubicBezier".
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* id, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isReactionLineEndingGeometricShapeSegmentCubicBezier(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2500,9 +2500,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2523,9 +2523,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2546,9 +2546,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2569,9 +2569,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2592,9 +2592,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2615,9 +2615,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const double c_api_getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "href" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2645,11 +2645,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHref(SBMLDocument* document, const char* id, const char* href, int geometricShapeIndex = 0, int renderIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is set.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -1832,10 +1832,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxX(SBMLDocument* document, const char* id, const double x, int renderIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "y" attribute of the bounding box of the LineEnding object, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "x" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param x a double value to be set as "x" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "x" attribute of the bounding box of the all LineEnding objects associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param x a double value to be set as "x" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
@@ -1853,10 +1875,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxY(SBMLDocument* document, const char* id, const double y, int renderIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "y" attribute of the bounding box of the LineEnding object, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "y" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param y a double value to be set as "y" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "y" attribute of the bounding box of the all LineEnding objects associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param y a double value to be set as "y" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
@@ -1874,10 +1918,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxWidth(SBMLDocument* document, const char* id, const double width, int renderIndex = 0);
 
+    /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "width" attribute of the bounding box of the LineEnding object, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "width" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param width a double value to be set as "width" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "width" attribute of the bounding box of all LineEnding objects associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param width a double value to be set as "width" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
@@ -1895,10 +1961,32 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBoundingBoxHeight(SBMLDocument* document, const char* id, const double height, int renderIndex = 0);
 
+    /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "height" attribute of the bounding box of the LineEnding object, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "height" attribute of the bounding box of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param height a double value to be set as "height" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "height" attribute of the bounding box of all LineEnding objects associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param height a double value to be set as "height" attribute of the bounding box of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -1924,12 +2012,41 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderColor(SBMLDocument* document, const char* id, const char* borderColor, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return @c true if the "stroke" attribute of the RenderGroup of the LineEnding object is set, @c false if either the "stroke" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "stroke" attribute of the RenderGroup of the LineEnding object, or @c "" if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param borderColor a string value to use as the value of the "stroke" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param borderColor a string value to use as the value of the "stroke" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -1955,12 +2072,41 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingBorderWidth(SBMLDocument* document, const char* id, const double borderWidth, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object is set, @c false if either the "stroke-width" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "stroke-width" attribute of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param borderWidth a double value to use as the value of the "stroke-width" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param borderWidth a double value to use as the value of the "stroke-width" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
@@ -1983,12 +2129,44 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param renderIndex the index number of the RenderInformationBase object.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingNthBorderDash(SBMLDocument* document, const char* id, const int dash, int borderDashIndex, int renderIndex = 0);
 
+    /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const int c_api_getNumSpeciesReferenceLineEndingBorderDashes(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the dash at the given index of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param borderDashIndex the index of the border dash.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the value of the dash at the given index of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object, or @c 0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the dash at the given index of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param dash the value of the dash to set.
+    /// @param borderDashIndex the index of the border dash.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the dash at the given index of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param dash the value of the dash to set.
+    /// @param borderDashIndex the index of the border dash.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2014,18 +2192,77 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColor(SBMLDocument* document, const char* id, const char* fillColor, int renderIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document in the form of a gradient.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param id the id of the LineEnding object.
+    /// @param gradientType the type of the gradient.
+    /// @param stopColors an array of strings representing the colors of the gradient stops.
+    /// @param stopOffsets an array of doubles representing the offsets of the gradient stops.
+    /// @param stopsSize the size of the stopColors and stopOffsets arrays.
+    /// @param renderIndex the index number of the RenderInformationBase object.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillColorAsGradient(SBMLDocument* document, const char* id, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return @c true if the "fill" attribute of the RenderGroup of the LineEnding object is set, @c false if either the "fill" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "fill" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "fill" attribute of the RenderGroup of the LineEnding object, or @c "" if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document in the form of a gradient.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param gradientType the type of the gradient.
+    /// @param stopColors an array of strings representing the colors of the gradient stops.
+    /// @param stopOffsets an array of doubles representing the offsets of the gradient stops.
+    /// @param stopsSize the size of the stopColors and stopOffsets arrays.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document in the form of a gradient.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param gradientType the type of the gradient.
+    /// @param stopColors an array of strings representing the colors of the gradient stops.
+    /// @param stopOffsets an array of doubles representing the offsets of the gradient stops.
+    /// @param stopsSize the size of the stopColors and stopOffsets arrays.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2051,12 +2288,41 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingFillRule(SBMLDocument* document, const char* id, const char* fillRule, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object is set, @c false if either the "fill-rule" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return the "fill-rule" attribute of the RenderGroup of the LineEnding object, or @c "" if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param fillRule a string value to use as the value of the "fill-rule" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param fillRule a string value to use as the value of the "fill-rule" attribute of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns number of Transformation2D objects in the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
@@ -2077,6 +2343,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Rectangle or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRectangle(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type Rectangle.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Rectangle, @c false if either the Transformation2D object is not of type Rectangle or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
@@ -2088,6 +2362,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Ellipse or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingEllipse(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type Ellipse.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Ellipse, @c false if either the Transformation2D object is not of type Ellipse or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
@@ -2099,6 +2381,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Polygon or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingPolygon(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type Polygon.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Polygon, @c false if either the Transformation2D object is not of type Polygon or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
@@ -2110,6 +2400,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Image or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingImage(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type Image.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Image, @c false if either the Transformation2D object is not of type Image or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingImage(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
@@ -2121,6 +2419,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type RenderCurve or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingRenderCurve(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type RenderCurve.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type RenderCurve, @c false if either the Transformation2D object is not of type RenderCurve or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
@@ -2132,6 +2438,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// object is not of type Text or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isLineEndingText(SBMLDocument* document, const char* id, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is of type Text.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object is of type Text, @c false if either the Transformation2D object is not of type Text or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSpeciesReferenceLineEndingText(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2160,12 +2474,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeX(SBMLDocument* document, const char* id, const double x, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "x" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param x a double value to be set as "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param x a double value to be set as "x" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2194,12 +2541,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "y" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param y a double value to be set as "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param y a double value to be set as "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2228,12 +2608,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeWidth(SBMLDocument* document, const char* id, const double width, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "width" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param width a double value to be set as "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param width a double value to be set as "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2262,12 +2675,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "height" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param height a double value to be set as "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param height a double value to be set as "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2296,12 +2742,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRatio(SBMLDocument* document, const char* id, const double ratio, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "ratio" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param ratio a double value to be set as "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param ratio a double value to be set as "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2330,12 +2809,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "rx" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param rx a double value to be set as "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param rx a double value to be set as "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2364,12 +2876,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "ry" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param ry a double value to be set as "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param ry a double value to be set as "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2398,12 +2943,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* id, const double cx, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "cx" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param cx a double value to be set as "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param cx a double value to be set as "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2432,12 +3010,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* id, const double cy, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "cy" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param cy a double value to be set as "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param cy a double value to be set as "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2466,12 +3077,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double rx, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "rx" attribute is not set or the object is @c NULL.
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object, or @c 0.0 if the object is @c NULL.
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param rx a double value to be set as "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given reaction glyph of the given layout of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction.
+    /// @param rx a double value to be set as "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object.
+    /// @param reactionGlyphIndex the index of the reaction glyph.
+    /// @param layoutIndex the index of the layout.
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
@@ -2500,6 +3144,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function
     LIBSBMLNETWORK_EXTERN int c_api_setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* id, const double ry, int geometricShapeIndex = 0, int renderIndex = 0);
 
+    /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object associated with the given species reference glyph of the given reaction glyph of the given layout of the SBML document is set.
+    /// @param document a pointer to the SBMLDocument object
+    /// @param reactionId the id of the reaction
+    /// @param reactionGlyphIndex the index of the reaction glyph
+    /// @param speciesReferenceGlyphIndex the index of the species reference glyph
+    /// @param layoutIndex the index of the layout
+    /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve
+    /// @return @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object is set, @c false if either the "ry" attribute is not set or the object is @c NULL
     LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
@@ -2993,6 +3645,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFillColors(SBMLDocument* document, const char* fillColor, int layoutIndex = 0);
 
+    /// @brief Sets the value of the "fill" attribute of the RenderGroup of the Style of all GraphicalObjects objects in this Layout object as a gradient.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param gradientType a string value representing the type of gradient (e.g., "linear").
+    /// @param stopColors an array of string values representing the colors at each stop of the gradient.
+    /// @param stopOffsets an array of double values representing the offset at each stop of the gradient.
+    /// @param stopsSize an int representing the number of stops in the gradient.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFillColorsAsGradient(SBMLDocument* document, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
@@ -3021,6 +3681,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFillRule(SBMLDocument* document, const char* id, const char* fillRule, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the default value of the "fill-rule" attribute of the RenderGroup of the Global Style of CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "fill-rule" attribute of the RenderGroup of the Style for the global CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsFillRule(SBMLDocument* document);
 
     /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
@@ -3030,6 +3693,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFillRule(SBMLDocument* document, const char* fillRule, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "fill-rule" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFillRule(SBMLDocument* document);
 
     /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the Style of all GraphicalObject objects in this Layout object.
@@ -3039,8 +3705,16 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFillRule(SBMLDocument* document, const char* fillRule, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "fill-rule" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFillRule(SBMLDocument* document);
 
+    /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param fillRule a string value to use as the value of the "fill-rule" attribute of the RenderGroup of the Style for these GraphicalObject objects.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionsFillRule(SBMLDocument* document, const char* fillRule, int layoutIndex = 0);
 
     /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
@@ -3080,6 +3754,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontColor(SBMLDocument* document, const char* id, const char* fontColor, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "stroke" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsFontColor(SBMLDocument* document);
 
     /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
@@ -3089,6 +3766,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFontColor(SBMLDocument* document, const char* fontColor, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "stroke" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFontColor(SBMLDocument* document);
 
     /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph objects in this Layout object.
@@ -3098,6 +3778,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFontColor(SBMLDocument* document, const char* fontColor, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "stroke" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFontColor(SBMLDocument* document);
 
     /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph objects in this Layout object.
@@ -3143,6 +3826,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontFamily(SBMLDocument* document, const char* id, const char* fontFamily, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-family" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-family" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsFontFamily(SBMLDocument* document);
 
     /// @brief Sets the value of the "font-family" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
@@ -3152,15 +3838,21 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFontFamily(SBMLDocument* document, const char* fontFamily, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-family" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-family" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFontFamily(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-family" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph objects in this Layout object.
+    /// @brief Sets the value of the "font-family" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontFamily a string value to use as the value of the "font-family" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFontFamily(SBMLDocument* document, const char* fontFamily, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-family" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-family" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFontFamily(SBMLDocument* document);
 
     /// @breif Sets the value of the "font-family" attribute of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -3183,8 +3875,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param graphicalObjectIndex the index of the GraphicalObject to return.
     /// @param textGlyphIndex the index of the TextGlyph to return.
     /// @param layoutIndex the index number of the Layout to return.
-    /// @return @c true if the "font-size" attribute of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "font-size"
-    /// attribute is not set
+    /// @return @c true if the "font-size" attribute of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "font-size" attribute is not set
     LIBSBMLNETWORK_EXTERN bool c_api_isSetFontSize(SBMLDocument* document, const char* id, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "font-size" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
@@ -3206,48 +3897,56 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontSize(SBMLDocument* document, const char* id, const double fontSize, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-size" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-size" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsFontSize(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontSize a double value to use as the value of the "font-size" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFontSize(SBMLDocument* document, const double fontSize, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-size" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-size" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesFontSize(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph objects in this Layout object.
+    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontSize a double value to use as the value of the "font-size" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFontSize(SBMLDocument* document, const double fontSize, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-size" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-size" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsFontSize(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph objects in this Layout object.
+    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontSize a double value to use as the value of the "font-size" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionsFontSize(SBMLDocument* document, const double fontSize, int layoutIndex = 0);
 
-    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all GraphicalObject objects in this Layout object.
+    /// @brief Sets the value of the "font-size" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all GraphicalObject objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontSize a double value to use as the value of the "font-size" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontSizes(SBMLDocument* document, const double fontSize, int layoutIndex = 0);
 
-    /// @brief Predicates returning @c true if the "font-weight" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
+    /// @brief Predicates returning @c true if the "font-weight" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
     /// @param graphicalObjectIndex the index of the GraphicalObject to return.
     /// @param textGlyphIndex the index of the TextGlyph to return.
     /// @param layoutIndex the index number of the Layout to return.
-    /// @return @c true if the "font-weight" attribute of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "font-weight"
-    /// attribute is not set
+    /// @return @c true if the "font-weight" attribute of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "font-weight" attribute is not set
     LIBSBMLNETWORK_EXTERN bool c_api_isSetFontWeight(SBMLDocument* document, const char* id, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "font-weight" attribute of the RenderGroup of the Style that matches this id of model entity associated with the GraphicalObject.
@@ -3269,33 +3968,43 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontWeight(SBMLDocument* document, const char* id, const char* fontWeight, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-weight" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-weight" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsFontWeight(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontWeight a string value to use as the value of the "font-weight" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFontWeight(SBMLDocument* document, const char* fontWeight, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-weight" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-weight" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFontWeight(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontWeight a string value to use as the value of the "font-weight" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFontWeight(SBMLDocument* document, const char* fontWeight, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-weight" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-weight" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFontWeight(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontWeight a string value to use as the value of the "font-weight" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionsFontWeight(SBMLDocument* document, const char* fontWeight, int layoutIndex = 0);
 
-    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all GraphicalObject objects in this Layout object.
+    /// @brief Sets the value of the "font-weight" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all GraphicalObject objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontWeight a string value to use as the value of the "font-weight" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
@@ -3331,24 +4040,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setFontStyle(SBMLDocument* document, const char* id, const char* fontStyle, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-style" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-style" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsFontStyle(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-style" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-style" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontStyle a string value to use as the value of the "font-style" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsFontStyle(SBMLDocument* document, const char* fontStyle, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-style" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-style" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesFontStyle(SBMLDocument* document);
 
-    /// @brief Sets the value of the "font-style" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "font-style" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param fontStyle a string value to use as the value of the "font-style" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesFontStyle(SBMLDocument* document, const char* fontStyle, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "font-style" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "font-style" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsFontStyle(SBMLDocument* document);
 
     /// @brief Sets the value of the "font-style" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph object in this Layout object.
@@ -3394,24 +4112,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setTextHorizontalAlignment(SBMLDocument* document, const char* id, const char* textHorizontalAlignment, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsTextHorizontalAlignment(SBMLDocument* document);
 
-    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param textHorizontalAlignment a string value to use as the value of the "text-anchor" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsTextHorizontalAlignment(SBMLDocument* document, const char* textHorizontalAlignment, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesTextHorizontalAlignment(SBMLDocument* document);
 
-    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param textHorizontalAlignment a string value to use as the value of the "text-anchor" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesTextHorizontalAlignment(SBMLDocument* document, const char* textHorizontalAlignment, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsTextHorizontalAlignment(SBMLDocument* document);
 
     /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph object in this Layout object.
@@ -3457,24 +4184,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setTextVerticalAlignment(SBMLDocument* document, const char* id, const char* textVerticalAlignment, int graphicalObjectIndex = 0, int textGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsTextVerticalAlignment(SBMLDocument* document);
 
-    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param textVerticalAlignment a string value to use as the value of the "text-anchor" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsTextVerticalAlignment(SBMLDocument* document, const char* textVerticalAlignment, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all SpeciesGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesTextVerticalAlignment(SBMLDocument* document);
 
-    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the Style of the TextGlyph objects associated with all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param textVerticalAlignment a string value to use as the value of the "text-anchor" attribute of the RenderGroup of the Style for these GraphicalObject objects.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesTextVerticalAlignment(SBMLDocument* document, const char* textVerticalAlignment, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "text-anchor" attribute of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "text-anchor" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or @c "" if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsTextVerticalAlignment(SBMLDocument* document);
 
     /// @brief Sets the value of the "text-anchor" attribute of the RenderGroup of the the Style of the TextGlyph objects associated with of all ReactionGlyph object in this Layout object.
@@ -3804,24 +4540,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeX(SBMLDocument* document, const char* id, const double x, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeX(SBMLDocument* document, const double x, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeX(SBMLDocument* document, const double x, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeX(SBMLDocument* document);
 
     /// @brief Sets the value of the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -3868,34 +4613,45 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeY(SBMLDocument* document, const char* id, const double y, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeY(SBMLDocument* document, const double y, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
-    /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeY(SBMLDocument* document, const double y, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setReactionsGeometricShapeY(SBMLDocument* document, const double y, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all GraphicalObject objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the Transformation2D object for all GraphicalObject objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getGeometricShapeYs(SBMLDocument* document);
 
     /// @brief Sets the value of the "y" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all GraphicalObject object in this Layout object.
@@ -3935,24 +4691,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeWidth(SBMLDocument* document, const char* id, const double width, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "width" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeWidth(SBMLDocument* document);
 
-    /// @brief Sets the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param width a double to use as the value of the "width" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeWidth(SBMLDocument* document, const double width, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "width" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeWidth(SBMLDocument* document);
 
-    /// @brief Sets the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param width a double to use as the value of the "width" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeWidth(SBMLDocument* document, const double width, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "width" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeWidth(SBMLDocument* document);
 
     /// @brief Sets the value of the "width" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -3999,24 +4764,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeHeight(SBMLDocument* document, const char* id, const double height, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "height" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeHeight(SBMLDocument* document);
 
-    /// @brief Sets the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param height a double to use as the value of the "height" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeHeight(SBMLDocument* document, const double height, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "height" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeHeight(SBMLDocument* document);
 
-    /// @brief Sets the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param height a double to use as the value of the "height" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeHeight(SBMLDocument* document, const double height, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "height" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeHeight(SBMLDocument* document);
 
     /// @brief Sets the value of the "height" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4063,24 +4837,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeRatio(SBMLDocument* document, const char* id, const double ratio, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ratio" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeRatio(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param ratio a double to use as the value of the "ratio" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeRatio(SBMLDocument* document, const double ratio, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ratio" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeRatio(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param ratio a double to use as the value of the "ratio" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeRatio(SBMLDocument* document, const double ratio, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ratio" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeRatio(SBMLDocument* document);
 
     /// @brief Sets the value of the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4127,24 +4910,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeBorderRadiusX(SBMLDocument* document, const char* id, const double borderRadiusX, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeBorderRadiusX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param borderRadiusX a double to use as the value of the "rx" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeBorderRadiusX(SBMLDocument* document, const double borderRadiusX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeBorderRadiusX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param borderRadiusX a double to use as the value of the "rx" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeBorderRadiusX(SBMLDocument* document, const double borderRadiusX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeBorderRadiusX(SBMLDocument* document);
 
     /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4191,24 +4983,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeBorderRadiusY(SBMLDocument* document, const char* id, const double borderRadiusY, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+   /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeBorderRadiusY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param borderRadiusY a double to use as the value of the "ry" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeBorderRadiusY(SBMLDocument* document, const double borderRadiusY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeBorderRadiusY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param borderRadiusY a double to use as the value of the "ry" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeBorderRadiusY(SBMLDocument* document, const double borderRadiusY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeBorderRadiusY(SBMLDocument* document);
 
     /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4255,24 +5056,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeCenterX(SBMLDocument* document, const char* id, const double centerX, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cx" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeCenterX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param centerX a double to use as the value of the "cx" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeCenterX(SBMLDocument* document, const double centerX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cx" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeCenterX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param centerX a double to use as the value of the "cx" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeCenterX(SBMLDocument* document, const double centerX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cx" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeCenterX(SBMLDocument* document);
 
     /// @brief Sets the value of the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4319,24 +5129,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeCenterY(SBMLDocument* document, const char* id, const double centerY, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cy" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeCenterY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param centerY a double to use as the value of the "cy" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeCenterY(SBMLDocument* document, const double centerY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cy" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeCenterY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param centerY a double to use as the value of the "cy" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeCenterY(SBMLDocument* document, const double centerY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "cy" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeCenterY(SBMLDocument* document);
 
     /// @brief Sets the value of the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4383,15 +5202,21 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeRadiusX(SBMLDocument* document, const char* id, const double radiusX, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeRadiusX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param radiusX a double to use as the value of the "rx" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeRadiusX(SBMLDocument* document, const double radiusX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeRadiusX(SBMLDocument* document);
 
     /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
@@ -4401,6 +5226,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeRadiusX(SBMLDocument* document, const double radiusX, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "rx" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeRadiusX(SBMLDocument* document);
 
     /// @brief Sets the value of the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4447,24 +5275,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeRadiusY(SBMLDocument* document, const char* id, const double radiusY, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeRadiusY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param radiusY a double to use as the value of the "ry" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeRadiusY(SBMLDocument* document, const double radiusY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeRadiusY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param radiusY a double to use as the value of the "ry" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeRadiusY(SBMLDocument* document, const double radiusY, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "ry" attribute of the Transformation2D object for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeRadiusY(SBMLDocument* document);
 
     /// @brief Sets the value of the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4524,9 +5361,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentX(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4534,9 +5374,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentX(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentX(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4544,6 +5387,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentX(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentX(SBMLDocument* document);
 
     /// @brief Sets the value of the "x" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4585,9 +5431,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentY(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4595,9 +5444,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentY(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentY(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4605,6 +5457,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentY(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentY(SBMLDocument* document);
 
     /// @brief Sets the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4646,9 +5501,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentBasePoint1X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 1 of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentBasePoint1X(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of base point 1 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4656,9 +5514,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentBasePoint1X(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 1 of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentBasePoint1X(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of base point 1 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4666,6 +5527,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentBasePoint1X(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 1 of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentBasePoint1X(SBMLDocument* document);
 
     /// @brief Sets the value of the "x" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4706,9 +5570,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentBasePoint1Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+   /// @brief Returns the value of the "y" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 1 of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentBasePoint1Y(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of base point 1 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4716,9 +5583,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentBasePoint1Y(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 1 of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentBasePoint1Y(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of base point 1 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4726,6 +5596,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentBasePoint1Y(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of base point 1 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 1 of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentBasePoint1Y(SBMLDocument* document);
 
     /// @brief Sets the value of the "y" attribute of base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4766,9 +5639,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentBasePoint2X(SBMLDocument* document, const char* id, const double x, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 2 of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentBasePoint2X(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of base point 2 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4776,9 +5652,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentBasePoint2X(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 2 of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentBasePoint2X(SBMLDocument* document);
 
-    /// @brief Sets the value of the "x" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "x" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param x a double to use as the value of the "x" attribute of base point 2 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4786,6 +5665,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentBasePoint2X(SBMLDocument* document, const double x, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "x" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "x" attribute of base point 2 of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentBasePoint2X(SBMLDocument* document);
 
     /// @brief Sets the value of the "x" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4826,9 +5708,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeSegmentBasePoint2Y(SBMLDocument* document, const char* id, const double y, int segmentIndex = 0, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 2 of the element for all CompartmentGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getCompartmentsGeometricShapeSegmentBasePoint2Y(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of base point 2 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4836,9 +5721,12 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeSegmentBasePoint2Y(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 2 of the element for all SpeciesGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesGeometricShapeSegmentBasePoint2Y(SBMLDocument* document);
 
-    /// @brief Sets the value of the "y" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "y" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param y a double to use as the value of the "y" attribute of base point 2 of this element.
     /// @param segmentIndex an int representing the index of the element to retrieve.
@@ -4846,6 +5734,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeSegmentBasePoint2Y(SBMLDocument* document, const double y, int segmentIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "y" attribute of base point 2 of the element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "y" attribute of base point 2 of the element for all ReactionGlyph objects, or @c 0.0 if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const double c_api_getReactionsGeometricShapeSegmentBasePoint2Y(SBMLDocument* document);
 
     /// @brief Sets the value of the "y" attribute of base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.
@@ -4894,24 +5785,33 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setGeometricShapeHref(SBMLDocument* document, const char* id, const char* href, int geometricShapeIndex = 0, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "href" attribute of the Transformation2D object for all CompartmentGlyph objects, or @c NULL if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getCompartmentsGeometricShapeHref(SBMLDocument* document);
 
-    /// @brief Sets the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph object in this Layout object.
+    /// @brief Sets the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all CompartmentGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param href a string to use as the value of the "href" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsGeometricShapeHref(SBMLDocument* document, const char* href, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "href" attribute of the Transformation2D object for all SpeciesGlyph objects, or @c NULL if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesGeometricShapeHref(SBMLDocument* document);
 
-    /// @brief Sets the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph object in this Layout object.
+    /// @brief Sets the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all SpeciesGlyph objects in this Layout object.
     /// @param document a pointer to the SBMLDocument object.
     /// @param href a string to use as the value of the "href" attribute of this Transformation2D object.
     /// @param layoutIndex an int representing the index of the Layout to retrieve.
     /// @return integer value indicating success/failure of the function.
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesGeometricShapeHref(SBMLDocument* document, const char* href, int layoutIndex = 0);
 
+    /// @brief Returns the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph objects in this Layout object.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @return the "href" attribute of the Transformation2D object for all ReactionGlyph objects, or @c NULL if the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getReactionsGeometricShapeHref(SBMLDocument* document);
 
     /// @brief Sets the value of the "href" attribute of the Transformation2D at the given index of the RenderGroup of the Style of all ReactionGlyph object in this Layout object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -74,8 +74,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     /// @brief Create a Render object, add it to the the SBML document, and set all the necessary features for it.
     /// @param document a pointer to the SBMLDocument object.
+    /// @param maxNumConnectedEdges the maximum number of connected edges to a species glyph.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_autorender(SBMLDocument *document);
+    LIBSBMLNETWORK_EXTERN int c_api_autorender(SBMLDocument *document, const int maxNumConnectedEdges = 3);
 
     /// @brief Align the nodes position in the SBML document in the given alignment type.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -1836,6 +1836,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the value of the "y" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1854,6 +1856,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the value of the "width" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -1874,6 +1878,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the value of the "height" attribute of the bounding box of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1892,6 +1898,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -1922,6 +1930,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderColor(SBMLDocument* document, const char* reactionId, const char* borderColor, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -1951,6 +1961,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingBorderWidth(SBMLDocument* document, const char* reactionId, const double borderWidth, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
     /// @brief Returns the size of the "stroke-dasharray" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of a model entity.
@@ -1976,6 +1988,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingNthBorderDash(SBMLDocument* document, const char* reactionId, const int dash, int borderDashIndex, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @breif Predicates returning @c true if the "fill" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2010,6 +2024,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColor(SBMLDocument* document, const char* reactionId, const char* fillColor, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const char* reactionId, const char* gradientType = "linear", const char** stopColors = NULL, const double* stopOffsets = NULL, const int stopsSize = 0, int reactionGlyphIndex = 0, int layoutIndex = 0);
+
     /// @breif Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2038,6 +2056,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingFillRule(SBMLDocument* document, const char* reactionId, const char* fillRule, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns number of Transformation2D objects in the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2146,6 +2166,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "y" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2177,6 +2199,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "width" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2210,6 +2234,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const char* reactionId, const double width, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "height" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2241,6 +2267,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const char* reactionId, const double height, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ratio" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2274,6 +2302,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const char* reactionId, const double ratio, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2305,6 +2335,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2338,6 +2370,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBorderRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "cx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2369,6 +2403,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const char* reactionId, const double cx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "cy" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
@@ -2402,6 +2438,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const char* reactionId, const double cy, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "rx" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2434,6 +2472,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const char* reactionId, const double rx, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Predicates returning @c true if the "ry" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object
     /// @param id the id of the LineEnding object
@@ -2465,6 +2505,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const char* reactionId, const double ry, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the number of elements of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2504,6 +2546,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentX(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Returns the value of the "y" attribute of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2526,6 +2570,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeSegmentY(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2550,6 +2596,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Returns the value of the "y" attribute of the base point 1 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2572,6 +2620,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Returns the value of the "x" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2596,6 +2646,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const char* reactionId, const double x, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
     /// @brief Returns the value of the "y" attribute of the base point 2 of element at the given index of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param id the id of the LineEnding object.
@@ -2618,6 +2670,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const double c_api_getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const char* reactionId, const double y, int reactionGlyphIndex = 0, int layoutIndex = 0, int segmentIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "href" attribute of the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document.
     /// @param document a pointer to the SBMLDocument object.
@@ -2650,6 +2704,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     LIBSBMLNETWORK_EXTERN int c_api_setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int speciesReferenceGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
+
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const char* reactionId, const char* href, int reactionGlyphIndex = 0, int layoutIndex = 0, int geometricShapeIndex = 0);
 
     /// @brief Predicates returning @c true if the "stroke" attribute of the RenderGroup of the Style that matches this id of model entity associated with GraphicalObject is set.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -11,8 +11,12 @@ return 0;
 }
 
 Layout* getLayout(ListOfLayouts* listOfLayouts, unsigned int layoutIndex) {
-    if (listOfLayouts)
-        return listOfLayouts->get(layoutIndex);
+    if (listOfLayouts) {
+        if (layoutIndex < getNumLayouts(listOfLayouts))
+            return listOfLayouts->get(layoutIndex);
+
+        std::cerr << "error: layoutIndex is out of bounds." << std::endl;
+    }
 
     return NULL;
 }

--- a/src/libsbmlnetwork_layout_helpers.cpp
+++ b/src/libsbmlnetwork_layout_helpers.cpp
@@ -1082,43 +1082,46 @@ void distributeGraphicalObjectsHorizontally(Layout* layout, std::vector<Graphica
         return;
     double minX = getMinPositionX(graphicalObjects);
     double maxX = getMaxPositionX(graphicalObjects);
+    double minY = getMinPositionY(graphicalObjects);
+    double maxY = getMaxPositionY(graphicalObjects);
     double distance = findDistributionDistance(minX, maxX, graphicalObjects.size(), spacing);
-    if (graphicalObjects.size() % 2 == 0)
-        distributeEvenGraphicalObjectsHorizontally(layout, graphicalObjects, minX, maxX, distance);
-    else
-        distributeOddGraphicalObjectsHorizontally(layout, graphicalObjects, minX, maxX, distance);
-}
-
-void distributeEvenGraphicalObjectsHorizontally(Layout* layout, std::vector<GraphicalObject*> graphicalObjects, const double& minX, const double& maxX, const double& distance) {
-    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
-        setPositionX(layout, graphicalObjects.at(i), minX + i * distance);
-}
-
-void distributeOddGraphicalObjectsHorizontally(Layout* layout, std::vector<GraphicalObject*> graphicalObjects, const double& minX, const double& maxX, const double& distance) {
-    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
-        setPositionX(layout, graphicalObjects.at(i), 0.5 * (minX + maxX) + (i - 0.5 * (graphicalObjects.size() - 1)) * distance);
+    if (graphicalObjects.size() % 2 == 0) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++) {
+            setPositionX(layout, graphicalObjects.at(i), minX + i * distance);
+            setPositionY(layout, graphicalObjects.at(i), 0.5 * (minY + maxY));
+        }
+    }
+    else {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++) {
+            setPositionX(layout, graphicalObjects.at(i),
+                         0.5 * (minX + maxX) + (i - 0.5 * (graphicalObjects.size() - 1)) * distance);
+            setPositionY(layout, graphicalObjects.at(i), 0.5 * (minY + maxY));
+        }
+    }
 }
 
 void distributeGraphicalObjectsVertically(Layout* layout, std::vector<GraphicalObject*> graphicalObjects, const double& spacing) {
-    if (graphicalObjects.size() > 2)
+    if (graphicalObjects.size() < 2)
         return;
+    double minX = getMinPositionX(graphicalObjects);
+    double maxX = getMaxPositionX(graphicalObjects);
     double minY = getMinPositionY(graphicalObjects);
     double maxY = getMaxPositionY(graphicalObjects);
     double distance = findDistributionDistance(minY, maxY, graphicalObjects.size(), spacing);
-    if (graphicalObjects.size() % 2 == 0)
-        distributeEvenGraphicalObjectsVertically(layout, graphicalObjects, minY, maxY, distance);
-    else
-        distributeOddGraphicalObjectsVertically(layout, graphicalObjects, minY, maxY, distance);
-}
 
-void distributeEvenGraphicalObjectsVertically(Layout* layout, std::vector<GraphicalObject*> graphicalObjects, const double& minY, const double& maxY, const double& distance) {
-    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
-        setPositionY(layout, graphicalObjects.at(i), minY + i * distance);
-}
-
-void distributeOddGraphicalObjectsVertically(Layout* layout, std::vector<GraphicalObject*> graphicalObjects, const double& minY, const double& maxY, const double& distance) {
-    for (unsigned int i = 0; i < graphicalObjects.size(); i++)
-        setPositionY(layout, graphicalObjects.at(i), 0.5 * (minY + maxY) + (i - 0.5 * (graphicalObjects.size() - 1)) * distance);
+    if (graphicalObjects.size() % 2 == 0) {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++) {
+            setPositionX(layout, graphicalObjects.at(i), 0.5 * (minX + maxX));
+            setPositionY(layout, graphicalObjects.at(i), minY + i * distance);
+        }
+    }
+    else {
+        for (unsigned int i = 0; i < graphicalObjects.size(); i++) {
+            setPositionX(layout, graphicalObjects.at(i), 0.5 * (minX + maxX));
+            setPositionY(layout, graphicalObjects.at(i),
+                         0.5 * (minY + maxY) + (i - 0.5 * (graphicalObjects.size() - 1)) * distance);
+        }
+    }
 }
 
 const double findDistributionDistance(const double& minPosition, const double& maxPosition, const unsigned int& numGraphicalObjects, const double& spacing) {
@@ -1129,6 +1132,20 @@ const double findDistributionDistance(const double& minPosition, const double& m
         distance = (maxPosition - minPosition) / (numGraphicalObjects - 1);
 
     return distance;
+}
+
+std::vector<std::string> getSortedNodeIdsVector(std::set <std::pair<std::string, unsigned int>> nodeIds) {
+    std::vector<std::string> sortedNodeIdsVector;
+    for (unsigned int nodeIdIndex = 0; nodeIdIndex < nodeIds.size(); nodeIdIndex++) {
+        for (std::set<std::pair<std::string, unsigned int>>::const_iterator nodeIt = nodeIds.cbegin(); nodeIt != nodeIds.cend(); nodeIt++) {
+            if (nodeIt->second == nodeIdIndex) {
+                sortedNodeIdsVector.push_back(nodeIt->first);
+                break;
+            }
+        }
+    }
+
+    return sortedNodeIdsVector;
 }
 
 const double getMinPositionX(std::vector<GraphicalObject*> graphicalObjects) {

--- a/src/libsbmlnetwork_layout_helpers.h
+++ b/src/libsbmlnetwork_layout_helpers.h
@@ -264,6 +264,8 @@ void distributeOddGraphicalObjectsVertically(Layout* layout, std::vector<Graphic
 
 const double findDistributionDistance(const double& minPosition, const double& maxPosition, const unsigned int& numGraphicalObjects, const double& spacing);
 
+std::vector<std::string> getSortedNodeIdsVector(std::set <std::pair<std::string, unsigned int>> nodeIds);
+
 const double getMinPositionX(std::vector<GraphicalObject*> graphicalObjects);
 
 const double getMinPositionY(std::vector<GraphicalObject*> graphicalObjects);

--- a/src/libsbmlnetwork_layout_render.cpp
+++ b/src/libsbmlnetwork_layout_render.cpp
@@ -71,6 +71,9 @@ int setDefaultLocalRenderInformationFeatures(SBMLDocument* document, Layout* lay
 }
 
 int setCompartmentStrokeColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& stroke) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style* style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -85,6 +88,9 @@ int setCompartmentStrokeColor(Layout* layout, LocalRenderInformation* localRende
 }
 
 int setSpeciesStrokeColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& stroke) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -99,6 +105,9 @@ int setSpeciesStrokeColor(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setReactionStrokeColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& stroke) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -113,6 +122,9 @@ int setReactionStrokeColor(Layout* layout, LocalRenderInformation* localRenderIn
 }
 
 int setSpeciesReferenceStrokeColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& stroke) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         for (unsigned int j = 0; j < layout->getReactionGlyph(i)->getNumSpeciesReferenceGlyphs(); j++) {
@@ -129,6 +141,9 @@ int setSpeciesReferenceStrokeColor(Layout* layout, LocalRenderInformation* local
 }
 
 int setCompartmentStrokeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const double& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -142,6 +157,9 @@ int setCompartmentStrokeWidth(Layout* layout, LocalRenderInformation* localRende
 }
 
 int setSpeciesStrokeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const double& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -155,6 +173,9 @@ int setSpeciesStrokeWidth(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setReactionStrokeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const double& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -168,6 +189,9 @@ int setReactionStrokeWidth(Layout* layout, LocalRenderInformation* localRenderIn
 }
 
 int setSpeciesReferenceStrokeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const double& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         for (unsigned int j = 0; j < layout->getReactionGlyph(i)->getNumSpeciesReferenceGlyphs(); j++) {
@@ -183,6 +207,9 @@ int setSpeciesReferenceStrokeWidth(Layout* layout, LocalRenderInformation* local
 }
 
 int setCompartmentFontColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -199,6 +226,9 @@ int setCompartmentFontColor(Layout* layout, LocalRenderInformation* localRenderI
 }
 
 int setSpeciesFontColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -215,6 +245,9 @@ int setSpeciesFontColor(Layout* layout, LocalRenderInformation* localRenderInfor
 }
 
 int setReactionFontColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -231,6 +264,9 @@ int setReactionFontColor(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setCompartmentFontFamily(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontFamily) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -247,6 +283,9 @@ int setCompartmentFontFamily(Layout* layout, LocalRenderInformation* localRender
 }
 
 int setSpeciesFontFamily(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontFamily) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -263,6 +302,9 @@ int setSpeciesFontFamily(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setReactionFontFamily(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontFamily) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -279,6 +321,9 @@ int setReactionFontFamily(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setCompartmentFontSize(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -295,12 +340,18 @@ int setCompartmentFontSize(Layout* layout, LocalRenderInformation* localRenderIn
 }
 
 int setCompartmentFontSizeAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector fontSizeVector;
     fontSizeVector.setAbsoluteValue(fontSize);
     return setCompartmentFontSize(layout, localRenderInformation, fontSizeVector);
 }
 
 int setSpeciesFontSize(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -317,12 +368,18 @@ int setSpeciesFontSize(Layout* layout, LocalRenderInformation* localRenderInform
 }
 
 int setSpeciesFontSizeAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector fontSizeVector;
     fontSizeVector.setAbsoluteValue(fontSize);
     return setSpeciesFontSize(layout, localRenderInformation, fontSizeVector);
 }
 
 int setReactionFontSize(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -339,12 +396,18 @@ int setReactionFontSize(Layout* layout, LocalRenderInformation* localRenderInfor
 }
 
 int setReactionFontSizeAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& fontSize) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector fontSizeVector;
     fontSizeVector.setAbsoluteValue(fontSize);
     return setReactionFontSize(layout, localRenderInformation, fontSizeVector);
 }
 
 int setCompartmentFontWeight(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontWeight) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -361,6 +424,9 @@ int setCompartmentFontWeight(Layout* layout, LocalRenderInformation* localRender
 }
 
 int setSpeciesFontWeight(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontWeight) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -377,6 +443,9 @@ int setSpeciesFontWeight(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setReactionFontWeight(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontWeight) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -393,6 +462,9 @@ int setReactionFontWeight(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setCompartmentFontStyle(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontStyle) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -409,6 +481,9 @@ int setCompartmentFontStyle(Layout* layout, LocalRenderInformation* localRenderI
 }
 
 int setSpeciesFontStyle(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontStyle) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -425,6 +500,9 @@ int setSpeciesFontStyle(Layout* layout, LocalRenderInformation* localRenderInfor
 }
 
 int setReactionFontStyle(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fontStyle) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -441,6 +519,9 @@ int setReactionFontStyle(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setCompartmentTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& textAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -457,6 +538,9 @@ int setCompartmentTextAnchor(Layout* layout, LocalRenderInformation* localRender
 }
 
 int setSpeciesTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& textAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -473,6 +557,9 @@ int setSpeciesTextAnchor(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setReactionTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& textAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -489,6 +576,9 @@ int setReactionTextAnchor(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setCompartmentVTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& vTextAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getCompartmentGlyph(i));
@@ -505,6 +595,9 @@ int setCompartmentVTextAnchor(Layout* layout, LocalRenderInformation* localRende
 }
 
 int setSpeciesVTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& vTextAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getSpeciesGlyph(i));
@@ -521,6 +614,9 @@ int setSpeciesVTextAnchor(Layout* layout, LocalRenderInformation* localRenderInf
 }
 
 int setReactionVTextAnchor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& vTextAnchor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, layout->getReactionGlyph(i));
@@ -537,6 +633,9 @@ int setReactionVTextAnchor(Layout* layout, LocalRenderInformation* localRenderIn
 }
 
 int setCompartmentFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -551,6 +650,9 @@ int setCompartmentFillColor(Layout* layout, LocalRenderInformation* localRenderI
 }
 
 int setCompartmentFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -564,6 +666,9 @@ int setCompartmentFillColorAsGradient(Layout* layout, LocalRenderInformation* lo
 }
 
 int setSpeciesFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -578,6 +683,9 @@ int setSpeciesFillColor(Layout* layout, LocalRenderInformation* localRenderInfor
 }
 
 int setSpeciesFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -591,6 +699,9 @@ int setSpeciesFillColorAsGradient(Layout* layout, LocalRenderInformation* localR
 }
 
 int setReactionFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -605,6 +716,9 @@ int setReactionFillColor(Layout* layout, LocalRenderInformation* localRenderInfo
 }
 
 int setReactionFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -618,6 +732,9 @@ int setReactionFillColorAsGradient(Layout* layout, LocalRenderInformation* local
 }
 
 int setCompartmentFillRule(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillRule) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -631,6 +748,9 @@ int setCompartmentFillRule(Layout* layout, LocalRenderInformation* localRenderIn
 }
 
 int setSpeciesFillRule(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillRule) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -644,6 +764,9 @@ int setSpeciesFillRule(Layout* layout, LocalRenderInformation* localRenderInform
 }
 
 int setReactionFillRule(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillRule) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -657,6 +780,9 @@ int setReactionFillRule(Layout* layout, LocalRenderInformation* localRenderInfor
 }
 
 int setCompartmentGeometricShapeType(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& shape) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -670,6 +796,9 @@ int setCompartmentGeometricShapeType(Layout* layout, LocalRenderInformation* loc
 }
 
 int setSpeciesGeometricShapeType(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& shape) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -683,6 +812,9 @@ int setSpeciesGeometricShapeType(Layout* layout, LocalRenderInformation* localRe
 }
 
 int setReactionGeometricShapeType(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& shape) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -696,6 +828,9 @@ int setReactionGeometricShapeType(Layout* layout, LocalRenderInformation* localR
 }
 
 int setCompartmentGeometricShapeX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -709,12 +844,18 @@ int setCompartmentGeometricShapeX(Layout* layout, LocalRenderInformation* localR
 }
 
 int setCompartmentGeometricShapeXAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector xVector;
     xVector.setAbsoluteValue(x);
     return setCompartmentGeometricShapeX(layout, localRenderInformation, xVector);
 }
 
 int setSpeciesGeometricShapeX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -728,12 +869,18 @@ int setSpeciesGeometricShapeX(Layout* layout, LocalRenderInformation* localRende
 }
 
 int setSpeciesGeometricShapeXAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector xVector;
     xVector.setAbsoluteValue(x);
     return setSpeciesGeometricShapeX(layout, localRenderInformation, xVector);
 }
 
 int setReactionGeometricShapeX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -747,12 +894,18 @@ int setReactionGeometricShapeX(Layout* layout, LocalRenderInformation* localRend
 }
 
 int setReactionGeometricShapeXAsDouble(Layout* layout, LocalRenderInformation* localRenderInformation, const double& x) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     RelAbsVector xVector;
     xVector.setAbsoluteValue(x);
     return setReactionGeometricShapeX(layout, localRenderInformation, xVector);
 }
 
 int setCompartmentGeometricShapeY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -772,6 +925,9 @@ int setCompartmentGeometricShapeYAsDouble(Layout* layout, LocalRenderInformation
 }
 
 int setSpeciesGeometricShapeY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -791,6 +947,9 @@ int setSpeciesGeometricShapeYAsDouble(Layout* layout, LocalRenderInformation* lo
 }
 
 int setReactionGeometricShapeY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -810,6 +969,9 @@ int setReactionGeometricShapeYAsDouble(Layout* layout, LocalRenderInformation* l
 }
 
 int setCompartmentGeometricShapeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -829,6 +991,9 @@ int setCompartmentGeometricShapeWidthAsDouble(Layout* layout, LocalRenderInforma
 }
 
 int setSpeciesGeometricShapeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -848,6 +1013,9 @@ int setSpeciesGeometricShapeWidthAsDouble(Layout* layout, LocalRenderInformation
 }
 
 int setReactionGeometricShapeWidth(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& width) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -867,6 +1035,9 @@ int setReactionGeometricShapeWidthAsDouble(Layout* layout, LocalRenderInformatio
 }
 
 int setCompartmentGeometricShapeHeight(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& height) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -886,6 +1057,9 @@ int setCompartmentGeometricShapeHeightAsDouble(Layout* layout, LocalRenderInform
 }
 
 int setSpeciesGeometricShapeHeight(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& height) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -905,6 +1079,9 @@ int setSpeciesGeometricShapeHeightAsDouble(Layout* layout, LocalRenderInformatio
 }
 
 int setReactionGeometricShapeHeight(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& height) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -924,6 +1101,9 @@ int setReactionGeometricShapeHeightAsDouble(Layout* layout, LocalRenderInformati
 }
 
 int setCompartmentGeometricShapeRatio(Layout* layout, LocalRenderInformation* localRenderInformation, const double& ratio) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -937,6 +1117,9 @@ int setCompartmentGeometricShapeRatio(Layout* layout, LocalRenderInformation* lo
 }
 
 int setSpeciesGeometricShapeRatio(Layout* layout, LocalRenderInformation* localRenderInformation, const double& ratio) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -963,6 +1146,9 @@ int setReactionGeometricShapeRatio(Layout* layout, LocalRenderInformation* local
 }
 
 int setCompartmentGeometricShapeCornerCurvatureRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -982,6 +1168,9 @@ int setCompartmentGeometricShapeCornerCurvatureRadiusXAsDouble(Layout* layout, L
 }
 
 int setSpeciesGeometricShapeCornerCurvatureRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1001,6 +1190,9 @@ int setSpeciesGeometricShapeCornerCurvatureRadiusXAsDouble(Layout* layout, Local
 }
 
 int setReactionGeometricShapeCornerCurvatureRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1020,6 +1212,9 @@ int setReactionGeometricShapeCornerCurvatureRadiusXAsDouble(Layout* layout, Loca
 }
 
 int setCompartmentGeometricShapeCornerCurvatureRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1039,6 +1234,9 @@ int setCompartmentGeometricShapeCornerCurvatureRadiusYAsDouble(Layout* layout, L
 }
 
 int setSpeciesGeometricShapeCornerCurvatureRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1058,6 +1256,9 @@ int setSpeciesGeometricShapeCornerCurvatureRadiusYAsDouble(Layout* layout, Local
 }
 
 int setReactionGeometricShapeCornerCurvatureRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1077,6 +1278,9 @@ int setReactionGeometricShapeCornerCurvatureRadiusYAsDouble(Layout* layout, Loca
 }
 
 int setCompartmentGeometricShapeCenterX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1096,6 +1300,9 @@ int setCompartmentGeometricShapeCenterXAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setSpeciesGeometricShapeCenterX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1115,6 +1322,9 @@ int setSpeciesGeometricShapeCenterXAsDouble(Layout* layout, LocalRenderInformati
 }
 
 int setReactionGeometricShapeCenterX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1134,6 +1344,9 @@ int setReactionGeometricShapeCenterXAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setCompartmentGeometricShapeCenterY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1153,6 +1366,9 @@ int setCompartmentGeometricShapeCenterYAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setSpeciesGeometricShapeCenterY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1172,6 +1388,9 @@ int setSpeciesGeometricShapeCenterYAsDouble(Layout* layout, LocalRenderInformati
 }
 
 int setReactionGeometricShapeCenterY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& centerY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1191,6 +1410,9 @@ int setReactionGeometricShapeCenterYAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setCompartmentGeometricShapeRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1210,6 +1432,9 @@ int setCompartmentGeometricShapeRadiusXAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setSpeciesGeometricShapeRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1229,6 +1454,9 @@ int setSpeciesGeometricShapeRadiusXAsDouble(Layout* layout, LocalRenderInformati
 }
 
 int setReactionGeometricShapeRadiusX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1248,6 +1476,9 @@ int setReactionGeometricShapeRadiusXAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setCompartmentGeometricShapeRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1267,6 +1498,9 @@ int setCompartmentGeometricShapeRadiusYAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setSpeciesGeometricShapeRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1286,6 +1520,9 @@ int setSpeciesGeometricShapeRadiusYAsDouble(Layout* layout, LocalRenderInformati
 }
 
 int setReactionGeometricShapeRadiusY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& radiusY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1305,6 +1542,9 @@ int setReactionGeometricShapeRadiusYAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setCompartmentGeometricShapeElementX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& elementX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1324,6 +1564,9 @@ int setCompartmentGeometricShapeElementXAsDouble(Layout* layout, LocalRenderInfo
 }
 
 int setSpeciesGeometricShapeElementX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& elementX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1343,6 +1586,9 @@ int setSpeciesGeometricShapeElementXAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setReactionGeometricShapeElementX(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& elementX) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1362,6 +1608,9 @@ int setReactionGeometricShapeElementXAsDouble(Layout* layout, LocalRenderInforma
 }
 
 int setCompartmentGeometricShapeElementY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& elementY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1400,6 +1649,9 @@ int setSpeciesGeometricShapeElementYAsDouble(Layout* layout, LocalRenderInformat
 }
 
 int setReactionGeometricShapeElementY(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& elementY) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1419,6 +1671,9 @@ int setReactionGeometricShapeElementYAsDouble(Layout* layout, LocalRenderInforma
 }
 
 int setCompartmentGeometricShapeBasePoint1X(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint1X) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1457,6 +1712,9 @@ int setSpeciesGeometricShapeBasePoint1XAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setReactionGeometricShapeBasePoint1X(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint1X) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1476,6 +1734,9 @@ int setReactionGeometricShapeBasePoint1XAsDouble(Layout* layout, LocalRenderInfo
 }
 
 int setCompartmentGeometricShapeBasePoint1Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint1Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1495,6 +1756,9 @@ int setCompartmentGeometricShapeBasePoint1YAsDouble(Layout* layout, LocalRenderI
 }
 
 int setSpeciesGeometricShapeBasePoint1Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint1Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1514,6 +1778,9 @@ int setSpeciesGeometricShapeBasePoint1YAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setReactionGeometricShapeBasePoint1Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint1Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1533,6 +1800,9 @@ int setReactionGeometricShapeBasePoint1YAsDouble(Layout* layout, LocalRenderInfo
 }
 
 int setCompartmentGeometricShapeBasePoint2X(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2X) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1552,6 +1822,9 @@ int setCompartmentGeometricShapeBasePoint2XAsDouble(Layout* layout, LocalRenderI
 }
 
 int setSpeciesGeometricShapeBasePoint2X(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2X) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1571,6 +1844,9 @@ int setSpeciesGeometricShapeBasePoint2XAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setReactionGeometricShapeBasePoint2X(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2X) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1590,6 +1866,9 @@ int setReactionGeometricShapeBasePoint2XAsDouble(Layout* layout, LocalRenderInfo
 }
 
 int setCompartmentGeometricShapeBasePoint2Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1609,6 +1888,9 @@ int setCompartmentGeometricShapeBasePoint2YAsDouble(Layout* layout, LocalRenderI
 }
 
 int setSpeciesGeometricShapeBasePoint2Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
@@ -1628,6 +1910,9 @@ int setSpeciesGeometricShapeBasePoint2YAsDouble(Layout* layout, LocalRenderInfor
 }
 
 int setReactionGeometricShapeBasePoint2Y(Layout* layout, LocalRenderInformation* localRenderInformation, const RelAbsVector& basePoint2Y) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
@@ -1647,6 +1932,9 @@ int setReactionGeometricShapeBasePoint2YAsDouble(Layout* layout, LocalRenderInfo
 }
 
 int setCompartmentGeometricShapeHref(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& href) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
@@ -1673,6 +1961,9 @@ int setSpeciesGeometricShapeHref(Layout* layout, LocalRenderInformation* localRe
 }
 
 int setReactionGeometricShapeHref(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& href) {
+    if (layout == NULL || localRenderInformation == NULL)
+        return -1;
+
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
         style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));

--- a/src/libsbmlnetwork_layout_render.cpp
+++ b/src/libsbmlnetwork_layout_render.cpp
@@ -550,6 +550,19 @@ int setCompartmentFillColor(Layout* layout, LocalRenderInformation* localRenderI
     return 0;
 }
 
+int setCompartmentFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    Style *style = NULL;
+    for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
+        style = getStyleById(localRenderInformation, layout->getCompartmentGlyph(i));
+        if (style) {
+            if (setFillColorAsGradient(style, gradientId))
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
 int setSpeciesFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor) {
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
@@ -564,6 +577,19 @@ int setSpeciesFillColor(Layout* layout, LocalRenderInformation* localRenderInfor
     return 0;
 }
 
+int setSpeciesFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    Style *style = NULL;
+    for (unsigned int i = 0; i < layout->getNumSpeciesGlyphs(); i++) {
+        style = getStyleById(localRenderInformation, layout->getSpeciesGlyph(i));
+        if (style) {
+            if (setFillColorAsGradient(style, gradientId))
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
 int setReactionFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor) {
     Style *style = NULL;
     for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
@@ -571,6 +597,19 @@ int setReactionFillColor(Layout* layout, LocalRenderInformation* localRenderInfo
         if (style) {
             addColor(localRenderInformation, fillColor);
             if (setFillColor(style, fillColor))
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
+int setReactionFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId) {
+    Style *style = NULL;
+    for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
+        style = getStyleById(localRenderInformation, layout->getReactionGlyph(i));
+        if (style) {
+            if (setFillColorAsGradient(style, gradientId))
                 return -1;
         }
     }

--- a/src/libsbmlnetwork_layout_render.h
+++ b/src/libsbmlnetwork_layout_render.h
@@ -118,9 +118,15 @@ LIBSBMLNETWORK_EXTERN int setReactionVTextAnchor(Layout* layout, LocalRenderInfo
 
 LIBSBMLNETWORK_EXTERN int setCompartmentFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setCompartmentFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId);
+
 LIBSBMLNETWORK_EXTERN int setSpeciesFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId);
+
 LIBSBMLNETWORK_EXTERN int setReactionFillColor(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setReactionFillColorAsGradient(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& gradientId);
 
 LIBSBMLNETWORK_EXTERN int setCompartmentFillRule(Layout* layout, LocalRenderInformation* localRenderInformation, const std::string& fillRule);
 

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -637,7 +637,7 @@ int setRadialGradientCx(RenderInformationBase* renderInformationBase, const std:
 }
 
 int setRadialGradientCx(GradientBase* gradientBase, const RelAbsVector& cx) {
-    if (isLinearGradient(gradientBase) && isValidGradientCxValue(cx)) {
+    if (isRadialGradient(gradientBase) && isValidGradientCxValue(cx)) {
         ((RadialGradient*) gradientBase)->setCx(cx);
         return 0;
     }
@@ -650,7 +650,7 @@ int setRadialGradientCxAsDouble(RenderInformationBase* renderInformationBase, co
 }
 
 int setRadialGradientCxAsDouble(GradientBase* gradientBase, const double& cx) {
-    if (isLinearGradient(gradientBase) && isValidGradientCxValue(cx)) {
+    if (isRadialGradient(gradientBase) && isValidGradientCxValue(cx)) {
         ((RadialGradient*) gradientBase)->getCx().setRelativeValue(cx);
         return 0;
     }
@@ -696,7 +696,7 @@ int setRadialGradientCy(RenderInformationBase* renderInformationBase, const std:
 }
 
 int setRadialGradientCy(GradientBase* gradientBase, const RelAbsVector& cy) {
-    if (isLinearGradient(gradientBase) && isValidGradientCyValue(cy)) {
+    if (isRadialGradient(gradientBase) && isValidGradientCyValue(cy)) {
         ((RadialGradient*)gradientBase)->setCy(cy);
         return 0;
     }
@@ -709,7 +709,7 @@ int setRadialGradientCyAsDouble(RenderInformationBase* renderInformationBase, co
 }
 
 int setRadialGradientCyAsDouble(GradientBase* gradientBase, const double& cy) {
-    if (isLinearGradient(gradientBase) && isValidGradientCyValue(cy)) {
+    if (isRadialGradient(gradientBase) && isValidGradientCyValue(cy)) {
         ((RadialGradient*)gradientBase)->getCy().setRelativeValue(cy);
         return 0;
     }
@@ -755,7 +755,7 @@ int setRadialGradientFx(RenderInformationBase* renderInformationBase, const std:
 }
 
 int setRadialGradientFx(GradientBase* gradientBase, const RelAbsVector& fx) {
-    if (isLinearGradient(gradientBase) && isValidGradientFxValue(fx)) {
+    if (isRadialGradient(gradientBase) && isValidGradientFxValue(fx)) {
         ((RadialGradient*)gradientBase)->setFx(fx);
         return 0;
     }
@@ -763,12 +763,12 @@ int setRadialGradientFx(GradientBase* gradientBase, const RelAbsVector& fx) {
     return -1;
 }
 
-int setRadialGradientFAsDoublex(RenderInformationBase* renderInformationBase, const std::string& sid, const double& fx) {
+int setRadialGradientFxAsDouble(RenderInformationBase* renderInformationBase, const std::string& sid, const double& fx) {
     return setRadialGradientFx(getGradientDefinition(renderInformationBase, sid), fx);
 }
 
 int setRadialGradientFxAsDouble(GradientBase* gradientBase, const double& fx) {
-    if (isLinearGradient(gradientBase) && isValidGradientFxValue(fx)) {
+    if (isRadialGradient(gradientBase) && isValidGradientFxValue(fx)) {
         ((RadialGradient*)gradientBase)->getFx().setRelativeValue(fx);
         return 0;
     }
@@ -814,7 +814,7 @@ int setRadialGradientFy(RenderInformationBase* renderInformationBase, const std:
 }
 
 int setRadialGradientFy(GradientBase* gradientBase, const RelAbsVector& fy) {
-    if (isLinearGradient(gradientBase) && isValidGradientFyValue(fy)) {
+    if (isRadialGradient(gradientBase) && isValidGradientFyValue(fy)) {
         ((RadialGradient*)gradientBase)->setFy(fy);
         return 0;
     }
@@ -827,7 +827,7 @@ int setRadialGradientFyAsDouble(RenderInformationBase* renderInformationBase, co
 }
 
 int setRadialGradientFyAsDouble(GradientBase* gradientBase, const double& fy) {
-    if (isLinearGradient(gradientBase) && isValidGradientFyValue(fy)) {
+    if (isRadialGradient(gradientBase) && isValidGradientFyValue(fy)) {
         ((RadialGradient*)gradientBase)->getFy().setRelativeValue(fy);
         return 0;
     }
@@ -863,7 +863,7 @@ const double getRadialGradientRAsDouble(RenderInformationBase* renderInformation
 
 const double getRadialGradientRAsDouble(GradientBase* gradientBase) {
     if (isRadialGradient(gradientBase))
-        return getRelativeValue(((RadialGradient*)gradientBase)->getR());
+        return getAbsoluteValue(((RadialGradient*)gradientBase)->getR());
 
     return NAN;
 }
@@ -873,7 +873,7 @@ int setRadialGradientR(RenderInformationBase* renderInformationBase, const std::
 }
 
 int setRadialGradientR(GradientBase* gradientBase, const RelAbsVector& r) {
-    if (isLinearGradient(gradientBase) && isValidGradientRValue(r)) {
+    if (isRadialGradient(gradientBase) && isValidGradientRValue(r)) {
         ((RadialGradient*)gradientBase)->setR(r);
         return 0;
     }
@@ -886,8 +886,9 @@ int setRadialGradientRAsDouble(RenderInformationBase* renderInformationBase, con
 }
 
 int setRadialGradientRAsDouble(GradientBase* gradientBase, const double& r) {
-    if (isLinearGradient(gradientBase) && isValidGradientRValue(r)) {
-        ((RadialGradient*)gradientBase)->getR().setRelativeValue(r);
+    if (isRadialGradient(gradientBase) && isValidGradientRValue(r)) {
+        ((RadialGradient*)gradientBase)->getR().setAbsoluteValue(r);
+        ((RadialGradient*)gradientBase)->getR().setRelativeValue(0);
         return 0;
     }
 
@@ -2789,6 +2790,47 @@ int setFillColor(Transformation2D* transformation2D, const std::string& fillColo
     return -1;
 }
 
+int setFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, std::string& gradientId) {
+    if (renderInformationBase && renderInformationBase->getGradientDefinition(gradientId)) {
+        return setFillColor(getStyle(renderInformationBase, graphicalObject), gradientId);
+    }
+
+    return -1;
+}
+
+int setFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& gradientId) {
+    if (renderInformationBase && renderInformationBase->getGradientDefinition(gradientId)) {
+        return setFillColor(getStyle(renderInformationBase, attribute), gradientId);
+    }
+
+    return -1;
+}
+
+int setFillColorAsGradient(Style* style, const std::string& gradientId) {
+    return setFillColorAsGradient(getRenderGroup(style), gradientId);
+}
+
+int setFillColorAsGradient(RenderGroup* renderGroup, const std::string& gradientId) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillColor(getGeometricShape(renderGroup)))
+        return setFillColorAsGradient(getGeometricShape(renderGroup), gradientId);
+
+    if (isRenderGroup(renderGroup)) {
+        renderGroup->setFill(gradientId);
+        return 0;
+    }
+
+    return -1;
+}
+
+int setFillColorAsGradient(Transformation2D* transformation2D, const std::string& gradientId) {
+    if (isGraphicalPrimitive2D(transformation2D)) {
+        ((GraphicalPrimitive2D *) transformation2D)->setFill(gradientId);
+        return 0;
+    }
+
+    return -1;
+}
+
 const std::string getCompartmentFillColor(GlobalRenderInformation* globalRenderInformation) {
     return getFillColor(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()));
 }
@@ -2798,6 +2840,17 @@ int setCompartmentFillColor(GlobalRenderInformation* globalRenderInformation, co
     if (style) {
         addColor(globalRenderInformation, fillColor);
         return setFillColor(style, fillColor);
+    }
+
+    return -1;
+}
+
+int setCompartmentFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId) {
+    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
+    if (style) {
+        if (globalRenderInformation->getGradientDefinition(gradientId)) {
+            return setFillColorAsGradient(style, gradientId);
+        }
     }
 
     return -1;
@@ -2817,6 +2870,17 @@ int setSpeciesFillColor(GlobalRenderInformation* globalRenderInformation, const 
     return -1;
 }
 
+int setSpeciesFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId) {
+    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
+    if (style) {
+        if (globalRenderInformation->getGradientDefinition(gradientId)) {
+            return setFillColorAsGradient(style, gradientId);
+        }
+    }
+
+    return -1;
+}
+
 const std::string getReactionFillColor(GlobalRenderInformation* globalRenderInformation) {
     return getFillColor(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()));
 }
@@ -2826,6 +2890,17 @@ int setReactionFillColor(GlobalRenderInformation* globalRenderInformation, const
     if (style) {
         addColor(globalRenderInformation, fillColor);
         return setFillColor(style, fillColor);
+    }
+
+    return -1;
+}
+
+int setReactionFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId) {
+    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
+    if (style) {
+        if (globalRenderInformation->getGradientDefinition(gradientId)) {
+            return setFillColorAsGradient(style, gradientId);
+        }
     }
 
     return -1;
@@ -3950,6 +4025,49 @@ int setGeometricShapeFillColor(Transformation2D* shape, const std::string& fillC
 
     return -1;
 }
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(renderInformationBase, graphicalObject, 0, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(renderInformationBase, attribute, 0, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(getStyle(renderInformationBase, attribute), geometricShapeIndex, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(Style* style, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(style, 0, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(Style* style, unsigned int geometricShapeIndex, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(getRenderGroup(style), geometricShapeIndex, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(RenderGroup* renderGroup, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(renderGroup, 0, gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& gradientId) {
+    return setGeometricShapeFillColorAsGradient(getGeometricShape(renderGroup, geometricShapeIndex), gradientId);
+}
+
+int setGeometricShapeFillColorAsGradient(Transformation2D* shape, const std::string& gradientId) {
+    if (isGraphicalPrimitive2D(shape)) {
+        ((GraphicalPrimitive2D*)shape)->setFillColor(gradientId);
+        return 0;
+    }
+
+    return -1;
+}
+
+
 
 bool isSetGeometricShapeX(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeX(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -28,8 +28,12 @@ const unsigned int getNumLocalRenderInformation(ListOfLocalRenderInformation* li
 }
 
 LocalRenderInformation* getLocalRenderInformation(ListOfLocalRenderInformation* listOfLocalRenderInformation, unsigned int renderIndex) {
-    if (listOfLocalRenderInformation)
-        return listOfLocalRenderInformation->get(renderIndex);
+    if (listOfLocalRenderInformation) {
+        if (renderIndex < listOfLocalRenderInformation->size())
+            return listOfLocalRenderInformation->get(renderIndex);
+
+        std::cerr << "error: renderIndex out of range" << std::endl;
+    }
 
     return NULL;
 }

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -1088,6 +1088,16 @@ bool isSetStrokeColor(Style* style) {
     return isSetStrokeColor(getRenderGroup(style));
 }
 
+bool isSetStrokeColor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeColor(getGeometricShape(renderGroup)))
+        return isSetStrokeColor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetStroke();
+
+    return false;
+}
+
 bool isSetStrokeColor(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive1D(transformation2D))
         return ((GraphicalPrimitive1D*)transformation2D)->isSetStroke();
@@ -1107,6 +1117,16 @@ const std::string getStrokeColor(Style* style) {
     return getStrokeColor(getRenderGroup(style));
 }
 
+const std::string getStrokeColor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeColor(getGeometricShape(renderGroup)))
+        return getStrokeColor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getStroke();
+
+    return "";
+}
+
 const std::string getStrokeColor(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive1D(transformation2D))
         return ((GraphicalPrimitive1D*)transformation2D)->getStroke();
@@ -1123,10 +1143,19 @@ int setStrokeColor(RenderInformationBase* renderInformationBase, const std::stri
 }
 
 int setStrokeColor(Style* style, const std::string& stroke) {
-    if (getNumGeometricShapes(style) == 1)
-        return setStrokeColor(getGeometricShape(style), stroke);
-
     return setStrokeColor(getRenderGroup(style), stroke);
+}
+
+int setStrokeColor(RenderGroup* renderGroup, const std::string& stroke) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeColor(getGeometricShape(renderGroup)))
+        return setStrokeColor(getGeometricShape(renderGroup), stroke);
+
+    if (isRenderGroup(renderGroup) && isValidStrokeColorValue(stroke)) {
+        renderGroup->setStroke(stroke);
+        return 0;
+    }
+
+    return -1;
 }
 
 int setStrokeColor(Transformation2D* transformation2D, const std::string& stroke) {
@@ -1139,15 +1168,7 @@ int setStrokeColor(Transformation2D* transformation2D, const std::string& stroke
 }
 
 const std::string getCompartmentStrokeColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getStrokeColor(getGeometricShape(style)).empty())
-            return getStrokeColor(getGeometricShape(style));
-        else
-            return getStrokeColor(style);
-    }
-
-    return "";
+    return getStrokeColor(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()));
 }
 
 int setCompartmentStrokeColor(GlobalRenderInformation* globalRenderInformation, const std::string& stroke) {
@@ -1161,15 +1182,7 @@ int setCompartmentStrokeColor(GlobalRenderInformation* globalRenderInformation, 
 }
 
 const std::string getSpeciesStrokeColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getStrokeColor(getGeometricShape(style)).empty())
-            return getStrokeColor(getGeometricShape(style));
-        else
-            return getStrokeColor(style);
-    }
-
-    return "";
+    return getStrokeColor(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()));
 }
 
 int setSpeciesStrokeColor(GlobalRenderInformation* globalRenderInformation, const std::string& stroke) {
@@ -1183,15 +1196,7 @@ int setSpeciesStrokeColor(GlobalRenderInformation* globalRenderInformation, cons
 }
 
 const std::string getReactionStrokeColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getStrokeColor(getGeometricShape(style)).empty())
-            return getStrokeColor(getGeometricShape(style));
-        else
-            return getStrokeColor(style);
-    }
-
-    return "";
+    return getStrokeColor(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()));
 }
 
 int setReactionStrokeColor(GlobalRenderInformation* globalRenderInformation, const std::string& stroke) {
@@ -1237,6 +1242,16 @@ bool isSetStrokeWidth(Style* style) {
     return isSetStrokeWidth(getRenderGroup(style));
 }
 
+bool isSetStrokeWidth(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeWidth(getGeometricShape(renderGroup)))
+        return isSetStrokeWidth(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetStrokeWidth();
+
+    return false;
+}
+
 bool isSetStrokeWidth(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive1D(transformation2D))
         return ((GraphicalPrimitive1D*)transformation2D)->isSetStrokeWidth();
@@ -1256,6 +1271,16 @@ const double getStrokeWidth(Style* style) {
     return getStrokeWidth(getRenderGroup(style));
 }
 
+const double getStrokeWidth(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeWidth(getGeometricShape(renderGroup)))
+        return getStrokeWidth(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getStrokeWidth();
+
+    return NAN;
+}
+
 const double getStrokeWidth(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive1D(transformation2D))
         return ((GraphicalPrimitive1D*)transformation2D)->getStrokeWidth();
@@ -1272,10 +1297,19 @@ int setStrokeWidth(RenderInformationBase* renderInformationBase, const std::stri
 }
 
 int setStrokeWidth(Style* style, const double& strokeWidth) {
-    if (getNumGeometricShapes(style) == 1)
-        return setStrokeWidth(getGeometricShape(style), strokeWidth);
-
     return setStrokeWidth(getRenderGroup(style), strokeWidth);
+}
+
+int setStrokeWidth(RenderGroup* renderGroup, const double& strokeWidth) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeWidth(getGeometricShape(renderGroup)))
+        return setStrokeWidth(getGeometricShape(renderGroup), strokeWidth);
+
+    if (isRenderGroup(renderGroup) && isValidStrokeWidthValue(strokeWidth)) {
+        renderGroup->setStrokeWidth(strokeWidth);
+        return 0;
+    }
+
+    return -1;
 }
 
 int setStrokeWidth(Transformation2D* transformation2D, const double& strokeWidth) {
@@ -1288,81 +1322,46 @@ int setStrokeWidth(Transformation2D* transformation2D, const double& strokeWidth
 }
 
 const double getCompartmentStrokeWidth(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && getStrokeWidth(getGeometricShape(style)) > 0.01)
-            return getStrokeWidth(getGeometricShape(style));
-        else
-            return getStrokeWidth(style);
-    }
-
-    return NAN;
+    return getStrokeWidth(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()));
 }
 
 int setCompartmentStrokeWidth(GlobalRenderInformation* globalRenderInformation, const double& strokeWidth) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style)
-        return setStrokeWidth(style, strokeWidth);
-
-    return -1;
+    return setStrokeWidth(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()), strokeWidth);
 }
 
 const double getSpeciesStrokeWidth(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && getStrokeWidth(getGeometricShape(style)) > 0.01)
-            return getStrokeWidth(getGeometricShape(style));
-        else
-            return getStrokeWidth(style);
-    }
-
-    return NAN;
+    return getStrokeWidth(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()));
 }
 
 int setSpeciesStrokeWidth(GlobalRenderInformation* globalRenderInformation, const double& strokeWidth) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style)
-        return setStrokeWidth(style, strokeWidth);
-
-    return -1;
+    return setStrokeWidth(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()), strokeWidth);
 }
 
 const double getReactionStrokeWidth(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && getStrokeWidth(getGeometricShape(style)) > 0.01)
-            return getStrokeWidth(getGeometricShape(style));
-        else
-            return getStrokeWidth(style);
-    }
-
-    return NAN;
+    return getStrokeWidth(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()));
 }
 
 int setReactionStrokeWidth(GlobalRenderInformation* globalRenderInformation, const double& strokeWidth) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style)
-        return setStrokeWidth(style, strokeWidth);
-
-    return -1;
+    return setStrokeWidth(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()), strokeWidth);
 }
 
 int setSpeciesReferenceStrokeWidth(GlobalRenderInformation* globalRenderInformation, const double& strokeWidth) {
+    bool stokeWidthIsSet = false;
     Style* style = getStyleByType(globalRenderInformation, getSpeciesReferenceGlyphStyleType());
     if (style) {
-        if (setStrokeWidth(style, strokeWidth))
-            return -1;
+        if (!setStrokeWidth(style, strokeWidth))
+            stokeWidthIsSet = true;
     }
     std::vector<std::pair<SpeciesReferenceRole_t, std::string>> styleRoles = getStyleRoles();
     for (unsigned int i = 0; i < styleRoles.size(); i++) {
         Style* style = getStyleByRole(globalRenderInformation, styleRoles[i].second);
         if (style) {
-            if (setStrokeWidth(style, strokeWidth))
-                return -1;
+            if (!setStrokeWidth(style, strokeWidth))
+                stokeWidthIsSet = true;
         }
     }
 
-    return -1;
+    return stokeWidthIsSet ? 0 : -1;
 }
 
 bool isSetStrokeDashArray(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject) {
@@ -1375,6 +1374,16 @@ bool isSetStrokeDashArray(RenderInformationBase* renderInformationBase, const st
 
 bool isSetStrokeDashArray(Style* style) {
     return isSetStrokeDashArray(getRenderGroup(style));
+}
+
+bool isSetStrokeDashArray(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return isSetStrokeDashArray(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetStrokeDashArray();
+
+    return false;
 }
 
 bool isSetStrokeDashArray(Transformation2D* transformation2D) {
@@ -1394,6 +1403,16 @@ const std::vector<unsigned int> getStrokeDashArray(RenderInformationBase* render
 
 const std::vector<unsigned int> getStrokeDashArray(Style* style) {
     return getStrokeDashArray(getRenderGroup(style));
+}
+
+const std::vector<unsigned int> getStrokeDashArray(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return getStrokeDashArray(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getStrokeDashArray();
+
+    return std::vector<unsigned int>();
 }
 
 const std::vector<unsigned int> getStrokeDashArray(Transformation2D* transformation2D) {
@@ -1418,6 +1437,18 @@ int setStrokeDashArray(Style* style, const std::vector<unsigned int>& strokeDash
     return setStrokeDashArray(getRenderGroup(style), strokeDashArray);
 }
 
+int setStrokeDashArray(RenderGroup* renderGroup, const std::vector<unsigned int>& strokeDashArray) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return setStrokeDashArray(getGeometricShape(renderGroup), strokeDashArray);
+
+    if (isRenderGroup(renderGroup) && isValidStrokeDashArrayValue(strokeDashArray)) {
+        renderGroup->setStrokeDashArray(strokeDashArray);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setStrokeDashArray(Transformation2D* transformation2D, const std::vector<unsigned int>& strokeDashArray) {
     if (isGraphicalPrimitive1D(transformation2D) && isValidStrokeDashArrayValue(strokeDashArray)) {
         ((GraphicalPrimitive1D*)transformation2D)->setStrokeDashArray(strokeDashArray);
@@ -1428,27 +1459,15 @@ int setStrokeDashArray(Transformation2D* transformation2D, const std::vector<uns
 }
 
 int setCompartmentStrokeDashArray(GlobalRenderInformation* globalRenderInformation, const std::vector<unsigned int>& strokeDashArray) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style)
-        return setStrokeDashArray(style, strokeDashArray);
-
-    return -1;
+    return setStrokeDashArray(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()), strokeDashArray);
 }
 
 int setSpeciesStrokeDashArray(GlobalRenderInformation* globalRenderInformation, const std::vector<unsigned int>& strokeDashArray) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style)
-        return setStrokeDashArray(style, strokeDashArray);
-
-    return -1;
+    return setStrokeDashArray(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()), strokeDashArray);
 }
 
 int setReactionStrokeDashArray(GlobalRenderInformation* globalRenderInformation, const std::vector<unsigned int>& strokeDashArray) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style)
-        return setStrokeDashArray(style, strokeDashArray);
-
-    return -1;
+    return setStrokeDashArray(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()), strokeDashArray);
 }
 
 unsigned int getNumStrokeDashes(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject) {
@@ -1461,6 +1480,16 @@ unsigned int getNumStrokeDashes(RenderInformationBase* renderInformationBase, co
 
 unsigned int getNumStrokeDashes(Style* style) {
     return getNumStrokeDashes(getRenderGroup(style));
+}
+
+unsigned int getNumStrokeDashes(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return getNumStrokeDashes(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return getStrokeDashArray(renderGroup).size();
+
+    return 0;
 }
 
 unsigned int getNumStrokeDashes(Transformation2D* transformation2D) {
@@ -1476,10 +1505,17 @@ unsigned int getStrokeDash(RenderInformationBase* renderInformationBase, const s
 }
 
 unsigned int getStrokeDash(Style* style, unsigned int strokeDashIndex) {
-    if (getNumGeometricShapes(style) == 1)
-        return setStrokeDash(getGeometricShape(style), strokeDashIndex);
-
     return setStrokeDash(getRenderGroup(style), strokeDashIndex);
+}
+
+unsigned int getStrokeDash(RenderGroup* renderGroup, unsigned int strokeDashIndex) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return getStrokeDash(getGeometricShape(renderGroup), strokeDashIndex);
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getDashByIndex(strokeDashIndex);
+
+    return NAN;
 }
 
 unsigned int getStrokeDash(Transformation2D* transformation2D, unsigned int strokeDashIndex) {
@@ -1510,10 +1546,23 @@ int setStrokeDash(Style* style, unsigned int dash) {
 }
 
 int setStrokeDash(Style* style, unsigned int strokeDashIndex, unsigned int dash) {
-    if (getNumGeometricShapes(style) == 1)
-        return setStrokeDash(getGeometricShape(style), strokeDashIndex, dash);
-
     return setStrokeDash(getRenderGroup(style), strokeDashIndex, dash);
+}
+
+int setStrokeDash(RenderGroup* renderGroup, unsigned int dash) {
+    return setStrokeDash(renderGroup, 0, dash);
+}
+
+int setStrokeDash(RenderGroup* renderGroup, unsigned int strokeDashIndex, unsigned int dash) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStrokeDashArray(getGeometricShape(renderGroup)))
+        return setStrokeDash(getGeometricShape(renderGroup), strokeDashIndex, dash);
+
+    if (isRenderGroup(renderGroup) && isValidStrokeDashValue(dash)) {
+        renderGroup->setDashByIndex(strokeDashIndex, dash);
+        return 0;
+    }
+
+    return -1;
 }
 
 int setStrokeDash(Transformation2D* transformation2D, unsigned int dash) {
@@ -1530,27 +1579,15 @@ int setStrokeDash(Transformation2D* transformation2D, unsigned int strokeDashInd
 }
 
 int setCompartmentStrokeDash(GlobalRenderInformation* globalRenderInformation, unsigned int dash) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style)
-        return setStrokeDash(style, dash);
-
-    return -1;
+    return setStrokeDash(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()), dash);
 }
 
 int setSpeciesStrokeDash(GlobalRenderInformation* globalRenderInformation, unsigned int dash) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style)
-        return setStrokeDash(style, dash);
-
-    return -1;
+    return setStrokeDash(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()), dash);
 }
 
 int setReactionStrokeDash(GlobalRenderInformation* globalRenderInformation, unsigned int dash) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style)
-        return setStrokeDash(style, dash);
-
-    return -1;
+    return setStrokeDash(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()), dash);
 }
 
 bool isSetFontColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject) {
@@ -1563,6 +1600,10 @@ bool isSetFontColor(RenderInformationBase* renderInformationBase, const std::str
 
 bool isSetFontColor(Style* style) {
     return isSetFontColor(getRenderGroup(style));
+}
+
+bool isSetFontColor(RenderGroup* renderGroup) {
+    return isSetStrokeColor(renderGroup);
 }
 
 bool isSetFontColor(Transformation2D* transformation2D) {
@@ -1581,6 +1622,10 @@ const std::string getFontColor(Style* style) {
     return getFontColor(getRenderGroup(style));
 }
 
+const std::string getFontColor(RenderGroup* renderGroup) {
+    return getStrokeColor(renderGroup);
+}
+
 const std::string getFontColor(Transformation2D* transformation2D) {
     return getStrokeColor(transformation2D);
 }
@@ -1595,6 +1640,10 @@ int setFontColor(RenderInformationBase* renderInformationBase, const std::string
 
 int setFontColor(Style* style, const std::string& fontColor) {
     return setFontColor(getRenderGroup(style), fontColor);
+}
+
+int setFontColor(RenderGroup* renderGroup, const std::string& fontColor) {
+    return setStrokeColor(renderGroup, fontColor);
 }
 
 int setFontColor(Transformation2D* transformation2D, const std::string& fontColor) {
@@ -1682,10 +1731,18 @@ bool isSetFontFamily(Style* style) {
     return isSetFontFamily(getRenderGroup(style));
 }
 
+bool isSetFontFamily(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontFamily(getGeometricShape(renderGroup)))
+        return isSetFontFamily(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFontFamily();
+
+    return false;
+}
+
 bool isSetFontFamily(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontFamily();
-    else if (isText(transformation2D))
+    if (isText(transformation2D))
         return ((RenderGroup*)transformation2D)->isSetFontFamily();
 
     return false;
@@ -1703,10 +1760,18 @@ const std::string getFontFamily(Style* style) {
     return getFontFamily(getRenderGroup(style));
 }
 
+const std::string getFontFamily(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontFamily(getGeometricShape(renderGroup)))
+        return getFontFamily(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFontFamily();
+
+    return "";
+}
+
 const std::string getFontFamily(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontFamily();
-    else if (isText(transformation2D))
+    if (isText(transformation2D))
         return ((RenderGroup*)transformation2D)->getFontFamily();
 
     return "";
@@ -1724,16 +1789,22 @@ int setFontFamily(Style* style, const std::string& fontFamily) {
     return setFontFamily(getRenderGroup(style), fontFamily);
 }
 
+int setFontFamily(RenderGroup* renderGroup, const std::string& fontFamily) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontFamily(getGeometricShape(renderGroup)))
+        return setFontFamily(getGeometricShape(renderGroup), fontFamily);
+
+    if (isRenderGroup(renderGroup) && isValidFontFamilyValue(fontFamily)) {
+        renderGroup->setFontFamily(fontFamily);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setFontFamily(Transformation2D* transformation2D, const std::string& fontFamily) {
-    if (isValidFontFamilyValue(fontFamily)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setFontFamily(fontFamily);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setFontFamily(fontFamily);
-            return 0;
-        }
+    if (isText(transformation2D) && isValidFontFamilyValue(fontFamily)) {
+        ((Text*)transformation2D)->setFontFamily(fontFamily);
+        return 0;
     }
 
     return -1;
@@ -1811,10 +1882,18 @@ bool isSetFontSize(Style* style) {
     return isSetFontSize(getRenderGroup(style));
 }
 
+bool isSetFontSize(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontSize(getGeometricShape(renderGroup)))
+        return isSetFontSize(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFontSize();
+
+    return false;
+}
+
 bool isSetFontSize(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontSize();
-    else if (isText(transformation2D))
+    if (isText(transformation2D))
         return ((RenderGroup*)transformation2D)->isSetFontSize();
 
     return false;
@@ -1832,12 +1911,20 @@ const RelAbsVector getFontSize(Style* style) {
     return getFontSize(getRenderGroup(style));
 }
 
+const RelAbsVector getFontSize(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontSize(getGeometricShape(renderGroup)))
+        return getFontSize(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFontSize();
+
+    return RelAbsVector(NAN, NAN);
+}
+
 const RelAbsVector getFontSize(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontSize();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontSize();
-    
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->getFontSize();
+
     return RelAbsVector(NAN, NAN);
 }
 
@@ -1853,16 +1940,22 @@ int setFontSize(Style* style, const RelAbsVector& fontSize) {
     return setFontSize(getRenderGroup(style), fontSize);
 }
 
+int setFontSize(RenderGroup* renderGroup, const RelAbsVector& fontSize) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontSize(getGeometricShape(renderGroup)))
+        return setFontSize(getGeometricShape(renderGroup), fontSize);
+
+    if (isRenderGroup(renderGroup) && isValidFontSizeValue(fontSize)) {
+        renderGroup->setFontSize(fontSize);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setFontSize(Transformation2D* transformation2D, const RelAbsVector& fontSize) {
-    if (isValidFontSizeValue(fontSize)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setFontSize(fontSize);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setFontSize(fontSize);
-            return 0;
-        }
+    if (isText(transformation2D) && isValidFontSizeValue(fontSize)) {
+        ((Text*)transformation2D)->setFontSize(fontSize);
+        return 0;
     }
 
     return -1;
@@ -1878,6 +1971,19 @@ int setFontSizeAsDouble(RenderInformationBase* renderInformationBase, const std:
 
 int setFontSizeAsDouble(Style* style, const double& fontSize) {
     return setFontSizeAsDouble(getRenderGroup(style), fontSize);
+}
+
+int setFontSizeAsDouble(RenderGroup* renderGroup, const double& fontSize) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontSize(getGeometricShape(renderGroup)))
+        return setFontSizeAsDouble(getGeometricShape(renderGroup), fontSize);
+
+    if (isRenderGroup(renderGroup)) {
+        RelAbsVector fontSizeRelAbs;
+        fontSizeRelAbs.setAbsoluteValue(fontSize);
+        return setFontSize(renderGroup, fontSizeRelAbs);
+    }
+
+    return -1;
 }
 
 int setFontSizeAsDouble(Transformation2D* transformation2D, const double& fontSize) {
@@ -2000,11 +2106,19 @@ bool isSetFontWeight(Style* style) {
     return isSetFontWeight(getRenderGroup(style));
 }
 
+bool isSetFontWeight(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontWeight(getGeometricShape(renderGroup)))
+        return isSetFontWeight(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFontWeight();
+
+    return false;
+}
+
 bool isSetFontWeight(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontWeight();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontWeight();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->isSetFontWeight();
 
     return false;
 }
@@ -2021,11 +2135,19 @@ const std::string getFontWeight(Style* style) {
     return getFontWeight(getRenderGroup(style));
 }
 
+const std::string getFontWeight(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontWeight(getGeometricShape(renderGroup)))
+        return getFontWeight(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFontWeightAsString();
+
+    return "";
+}
+
 const std::string getFontWeight(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontWeightAsString();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontWeightAsString();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->getFontWeightAsString();
 
     return "";
 }
@@ -2042,16 +2164,22 @@ int setFontWeight(Style* style, const std::string& fontWeight) {
     return setFontWeight(getRenderGroup(style), fontWeight);
 }
 
+int setFontWeight(RenderGroup* renderGroup, const std::string& fontWeight) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontWeight(getGeometricShape(renderGroup)))
+        return setFontWeight(getGeometricShape(renderGroup), fontWeight);
+
+    if (isRenderGroup(renderGroup) && isValidFontWeightValue(fontWeight)) {
+        renderGroup->setFontWeight(fontWeight);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setFontWeight(Transformation2D* transformation2D, const std::string& fontWeight) {
-    if (isValidFontWeightValue(fontWeight)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setFontWeight(fontWeight);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setFontWeight(fontWeight);
-            return 0;
-        }
+    if (isText(transformation2D) && isValidFontWeightValue(fontWeight)) {
+        ((Text*)transformation2D)->setFontWeight(fontWeight);
+        return 0;
     }
 
     return -1;
@@ -2129,11 +2257,19 @@ bool isSetFontStyle(Style* style) {
     return isSetFontStyle(getRenderGroup(style));
 }
 
+bool isSetFontStyle(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontStyle(getGeometricShape(renderGroup)))
+        return isSetFontStyle(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFontStyle();
+
+    return false;
+}
+
 bool isSetFontStyle(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontStyle();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetFontStyle();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->isSetFontStyle();
 
     return false;
 }
@@ -2150,11 +2286,19 @@ const std::string getFontStyle(Style* style) {
     return getFontStyle(getRenderGroup(style));
 }
 
+const std::string getFontStyle(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontStyle(getGeometricShape(renderGroup)))
+        return getFontStyle(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFontStyleAsString();
+
+    return "";
+}
+
 const std::string getFontStyle(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontStyleAsString();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->getFontStyleAsString();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->getFontStyleAsString();
 
     return "";
 }
@@ -2171,16 +2315,22 @@ int setFontStyle(Style* style, const std::string& fontStyle) {
     return setFontStyle(getRenderGroup(style), fontStyle);
 }
 
+int setFontStyle(RenderGroup* renderGroup, const std::string& fontStyle) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFontStyle(getGeometricShape(renderGroup)))
+        return setFontStyle(getGeometricShape(renderGroup), fontStyle);
+
+    if (isRenderGroup(renderGroup) && isValidFontStyleValue(fontStyle)) {
+        renderGroup->setFontStyle(fontStyle);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setFontStyle(Transformation2D* transformation2D, const std::string& fontStyle) {
-    if (isValidFontStyleValue(fontStyle)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setFontStyle(fontStyle);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setFontStyle(fontStyle);
-            return 0;
-        }
+    if (isText(transformation2D) && isValidFontStyleValue(fontStyle)) {
+        ((Text*)transformation2D)->setFontStyle(fontStyle);
+        return 0;
     }
 
     return -1;
@@ -2258,11 +2408,19 @@ bool isSetTextAnchor(Style* style) {
     return isSetTextAnchor(getRenderGroup(style));
 }
 
+bool isSetTextAnchor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetTextAnchor(getGeometricShape(renderGroup)))
+        return isSetTextAnchor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetTextAnchor();
+
+    return false;
+}
+
 bool isSetTextAnchor(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetTextAnchor();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetTextAnchor();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->isSetTextAnchor();
 
     return false;
 }
@@ -2279,11 +2437,19 @@ const std::string getTextAnchor(Style* style) {
     return getTextAnchor(getRenderGroup(style));
 }
 
+const std::string getTextAnchor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetTextAnchor(getGeometricShape(renderGroup)))
+        return getTextAnchor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getTextAnchorAsString();
+
+    return "";
+}
+
 const std::string getTextAnchor(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getTextAnchorAsString();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->getTextAnchorAsString();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->getTextAnchorAsString();
 
     return "";
 }
@@ -2300,16 +2466,22 @@ int setTextAnchor(Style* style, const std::string& textAnchor) {
     return setTextAnchor(getRenderGroup(style), textAnchor);
 }
 
+int setTextAnchor(RenderGroup* renderGroup, const std::string& textAnchor) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetTextAnchor(getGeometricShape(renderGroup)))
+        return setTextAnchor(getGeometricShape(renderGroup), textAnchor);
+
+    if (isRenderGroup(renderGroup) && isValidTextAnchorValue(textAnchor)) {
+        renderGroup->setTextAnchor(textAnchor);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setTextAnchor(Transformation2D* transformation2D, const std::string& textAnchor) {
-    if (isValidTextAnchorValue(textAnchor)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setTextAnchor(textAnchor);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setTextAnchor(textAnchor);
-            return 0;
-        }
+    if (isText(transformation2D) && isValidTextAnchorValue(textAnchor)) {
+        ((Text*)transformation2D)->setTextAnchor(textAnchor);
+        return 0;
     }
 
     return -1;
@@ -2387,11 +2559,19 @@ bool isSetVTextAnchor(Style* style) {
     return isSetVTextAnchor(getRenderGroup(style));
 }
 
+bool isSetVTextAnchor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetVTextAnchor(getGeometricShape(renderGroup)))
+        return isSetVTextAnchor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetVTextAnchor();
+
+    return false;
+}
+
 bool isSetVTextAnchor(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetVTextAnchor();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetVTextAnchor();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->isSetVTextAnchor();
 
     return false;
 }
@@ -2408,11 +2588,19 @@ const std::string getVTextAnchor(Style* style) {
     return getVTextAnchor(getRenderGroup(style));
 }
 
+const std::string getVTextAnchor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetVTextAnchor(getGeometricShape(renderGroup)))
+        return getVTextAnchor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getVTextAnchorAsString();
+
+    return "";
+}
+
 const std::string getVTextAnchor(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getVTextAnchorAsString();
-    else if (isText(transformation2D))
-        return ((RenderGroup*)transformation2D)->getVTextAnchorAsString();
+    if (isText(transformation2D))
+        return ((Text*)transformation2D)->getVTextAnchorAsString();
 
     return "";
 }
@@ -2429,18 +2617,24 @@ int setVTextAnchor(Style* style, const std::string& vtextAnchor) {
     return setVTextAnchor(getRenderGroup(style), vtextAnchor);
 }
 
-int setVTextAnchor(Transformation2D* transformation2D, const std::string& vtextAnchor) {
-    if (isValidVTextAnchorValue(vtextAnchor)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setVTextAnchor(vtextAnchor);
-            return 0;
-        }
-        else if (isText(transformation2D)) {
-            ((Text*)transformation2D)->setVTextAnchor(vtextAnchor);
-            return 0;
-        }
+int setVTextAnchor(RenderGroup* renderGroup, const std::string& vtextAnchor) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetVTextAnchor(getGeometricShape(renderGroup)))
+        return setVTextAnchor(getGeometricShape(renderGroup), vtextAnchor);
+
+    if (isRenderGroup(renderGroup) && isValidVTextAnchorValue(vtextAnchor)) {
+        renderGroup->setVTextAnchor(vtextAnchor);
+        return 0;
     }
-    
+
+    return -1;
+}
+
+int setVTextAnchor(Transformation2D* transformation2D, const std::string& vtextAnchor) {
+    if (isText(transformation2D) && isValidVTextAnchorValue(vtextAnchor)) {
+        ((Text*)transformation2D)->setVTextAnchor(vtextAnchor);
+        return 0;
+    }
+
     return -1;
 }
 
@@ -2516,6 +2710,16 @@ bool isSetFillColor(Style* style) {
     return isSetFillColor(getRenderGroup(style));
 }
 
+bool isSetFillColor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillColor(getGeometricShape(renderGroup)))
+        return isSetFillColor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFill();
+
+    return false;
+}
+
 bool isSetFillColor(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive2D(transformation2D))
         return ((GraphicalPrimitive2D*)transformation2D)->isSetFill();
@@ -2535,6 +2739,16 @@ const std::string getFillColor(Style* style) {
     return getFillColor(getRenderGroup(style));
 }
 
+const std::string getFillColor(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillColor(getGeometricShape(renderGroup)))
+        return getFillColor(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFill();
+
+    return "";
+}
+
 const std::string getFillColor(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive2D(transformation2D))
         return ((GraphicalPrimitive2D*)transformation2D)->getFill();
@@ -2551,10 +2765,19 @@ int setFillColor(RenderInformationBase* renderInformationBase, const std::string
 }
 
 int setFillColor(Style* style, const std::string& fillColor) {
-    if (getNumGeometricShapes(style) == 1)
-        return setFillColor(getGeometricShape(style), fillColor);
-
     return setFillColor(getRenderGroup(style), fillColor);
+}
+
+int setFillColor(RenderGroup* renderGroup, const std::string& fillColor) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillColor(getGeometricShape(renderGroup)))
+        return setFillColor(getGeometricShape(renderGroup), fillColor);
+
+    if (isRenderGroup(renderGroup) && isValidFillColorValue(fillColor)) {
+        renderGroup->setFill(fillColor);
+        return 0;
+    }
+
+    return -1;
 }
 
 int setFillColor(Transformation2D* transformation2D, const std::string& fillColor) {
@@ -2567,15 +2790,7 @@ int setFillColor(Transformation2D* transformation2D, const std::string& fillColo
 }
 
 const std::string getCompartmentFillColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillColor(getGeometricShape(style)).empty())
-            return getFillColor(getGeometricShape(style));
-
-        return getFillColor(style);
-    }
-
-    return "";
+    return getFillColor(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()));
 }
 
 int setCompartmentFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor) {
@@ -2589,15 +2804,7 @@ int setCompartmentFillColor(GlobalRenderInformation* globalRenderInformation, co
 }
 
 const std::string getSpeciesFillColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillColor(getGeometricShape(style)).empty())
-            return getFillColor(getGeometricShape(style));
-
-        return getFillColor(style);
-    }
-
-    return "";
+    return getFillColor(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()));
 }
 
 int setSpeciesFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor) {
@@ -2611,15 +2818,7 @@ int setSpeciesFillColor(GlobalRenderInformation* globalRenderInformation, const 
 }
 
 const std::string getReactionFillColor(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillColor(getGeometricShape(style)).empty())
-            return getFillColor(getGeometricShape(style));
-
-        return getFillColor(style);
-    }
-
-    return "";
+    return getFillColor(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()));
 }
 
 int setReactionFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor) {
@@ -2644,6 +2843,16 @@ bool isSetFillRule(Style* style) {
     return isSetFillRule(getRenderGroup(style));
 }
 
+bool isSetFillRule(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillRule(getGeometricShape(renderGroup)))
+        return isSetFillRule(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetFillRule();
+
+    return false;
+}
+
 bool isSetFillRule(Transformation2D* transformation2D) {
     if (isGraphicalPrimitive2D(transformation2D))
         return ((GraphicalPrimitive2D*)transformation2D)->isSetFillRule();
@@ -2661,6 +2870,16 @@ const std::string getFillRule(RenderInformationBase* renderInformationBase, cons
 
 const std::string getFillRule(Style* style) {
     return getFillRule(getRenderGroup(style));
+}
+
+const std::string getFillRule(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillRule(getGeometricShape(renderGroup)))
+        return getFillRule(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getFillRuleAsString();
+
+    return "";
 }
 
 const std::string getFillRule(Transformation2D* transformation2D) {
@@ -2682,6 +2901,18 @@ int setFillRule(Style* style, const std::string& fillRule) {
     return setFillRule(getRenderGroup(style), fillRule);
 }
 
+int setFillRule(RenderGroup* renderGroup, const std::string& fillRule) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetFillRule(getGeometricShape(renderGroup)))
+        return setFillRule(getGeometricShape(renderGroup), fillRule);
+
+    if (isRenderGroup(renderGroup) && isValidFillRuleValue(fillRule)) {
+        renderGroup->setFillRule(fillRule);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setFillRule(Transformation2D* transformation2D, const std::string& fillRule) {
     if (isGraphicalPrimitive2D(transformation2D) && isValidFillRuleValue(fillRule)) {
         ((GraphicalPrimitive2D*)transformation2D)->setFillRule(fillRule);
@@ -2692,63 +2923,27 @@ int setFillRule(Transformation2D* transformation2D, const std::string& fillRule)
 }
 
 const std::string getCompartmentFillRule(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillRule(getGeometricShape(style)).empty())
-            return getFillRule(getGeometricShape(style));
-
-        return getFillRule(style);
-    }
-
-    return "";
+    return getFillRule(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()));
 }
 
 int setCompartmentFillRule(GlobalRenderInformation* globalRenderInformation, const std::string& fillRule) {
-    Style* style = getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType());
-    if (style)
-        return setFillRule(style, fillRule);
-
-    return -1;
+    return setFillRule(getStyleByType(globalRenderInformation, getCompartmentGlyphStyleType()), fillRule);
 }
 
 const std::string getSpeciesFillRule(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillRule(getGeometricShape(style)).empty())
-            return getFillRule(getGeometricShape(style));
-
-        return getFillRule(style);
-    }
-
-    return "";
+    return getFillRule(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()));
 }
 
 int setSpeciesFillRule(GlobalRenderInformation* globalRenderInformation, const std::string& fillRule) {
-    Style* style = getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType());
-    if (style)
-        return setFillRule(style, fillRule);
-
-    return -1;
+    return setFillRule(getStyleByType(globalRenderInformation, getSpeciesGlyphStyleType()), fillRule);
 }
 
 const std::string getReactionFillRule(GlobalRenderInformation* globalRenderInformation) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style) {
-        if (getNumGeometricShapes(style) == 1 && !getFillRule(getGeometricShape(style)).empty())
-            return getFillRule(getGeometricShape(style));
-
-        return getFillRule(style);
-    }
-
-    return "";
+    return getFillRule(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()));
 }
 
 int setReactionFillRule(GlobalRenderInformation* globalRenderInformation, const std::string& fillRule) {
-    Style* style = getStyleByType(globalRenderInformation, getReactionGlyphStyleType());
-    if (style)
-        return setFillRule(style, fillRule);
-
-    return -1;
+    return setFillRule(getStyleByType(globalRenderInformation, getReactionGlyphStyleType()), fillRule);
 }
 
 bool isSetStartHead(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject) {
@@ -2763,10 +2958,18 @@ bool isSetStartHead(Style* style) {
     return isSetStartHead(getRenderGroup(style));
 }
 
+bool isSetStartHead(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStartHead(getGeometricShape(renderGroup)))
+        return isSetStartHead(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetStartHead();
+
+    return false;
+}
+
 bool isSetStartHead(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetStartHead();
-    else if (isRenderCurve(transformation2D))
+    if (isRenderCurve(transformation2D))
         return ((RenderCurve*)transformation2D)->isSetStartHead();
 
     return false;
@@ -2784,10 +2987,18 @@ const std::string getStartHead(Style* style) {
     return getStartHead(getRenderGroup(style));
 }
 
+const std::string getStartHead(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStartHead(getGeometricShape(renderGroup)))
+        return getStartHead(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getStartHead();
+
+    return "";
+}
+
 const std::string getStartHead(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getStartHead();
-    else if (isRenderCurve(transformation2D))
+    if (isRenderCurve(transformation2D))
         return ((RenderCurve*)transformation2D)->getStartHead();
 
     return "";
@@ -2805,16 +3016,22 @@ int setStartHead(Style* style, const std::string& startHead) {
     return setStartHead(getRenderGroup(style), startHead);
 }
 
+int setStartHead(RenderGroup* renderGroup, const std::string& startHead) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetStartHead(getGeometricShape(renderGroup)))
+        return setStartHead(getGeometricShape(renderGroup), startHead);
+
+    if (isRenderGroup(renderGroup) && isValidStartHeadValue(startHead)) {
+        renderGroup->setStartHead(startHead);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setStartHead(Transformation2D* transformation2D, const std::string startHead) {
-    if (isValidStartHeadValue(startHead)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setStartHead(startHead);
-            return 0;
-        }
-        else if (isRenderCurve(transformation2D)) {
-            ((RenderCurve*)transformation2D)->setStartHead(startHead);
-            return 0;
-        }
+    if (isRenderCurve(transformation2D) && isValidStartHeadValue(startHead)) {
+        ((RenderCurve*)transformation2D)->setStartHead(startHead);
+        return 0;
     }
 
     return -1;
@@ -2832,10 +3049,18 @@ bool isSetEndHead(Style* style) {
     return isSetEndHead(getRenderGroup(style));
 }
 
+bool isSetEndHead(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetEndHead(getGeometricShape(renderGroup)))
+        return isSetEndHead(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->isSetEndHead();
+
+    return false;
+}
+
 bool isSetEndHead(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->isSetEndHead();
-    else if (isRenderCurve(transformation2D))
+    if (isRenderCurve(transformation2D))
         return ((RenderCurve*)transformation2D)->isSetEndHead();
 
     return false;
@@ -2853,10 +3078,18 @@ const std::string getEndHead(Style* style) {
     return getEndHead(getRenderGroup(style));
 }
 
+const std::string getEndHead(RenderGroup* renderGroup) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetEndHead(getGeometricShape(renderGroup)))
+        return getEndHead(getGeometricShape(renderGroup));
+
+    if (isRenderGroup(renderGroup))
+        return renderGroup->getEndHead();
+
+    return "";
+}
+
 const std::string getEndHead(Transformation2D* transformation2D) {
-    if (isRenderGroup(transformation2D))
-        return ((RenderGroup*)transformation2D)->getEndHead();
-    else if (isRenderCurve(transformation2D))
+    if (isRenderCurve(transformation2D))
         return ((RenderCurve*)transformation2D)->getEndHead();
 
     return "";
@@ -2874,16 +3107,22 @@ int setEndHead(Style* style, const std::string& endHead) {
     return setEndHead(getRenderGroup(style), endHead);
 }
 
+int setEndHead(RenderGroup* renderGroup, const std::string& endHead) {
+    if (getNumGeometricShapes(renderGroup) == 1 && isSetEndHead(getGeometricShape(renderGroup)))
+        return setEndHead(getGeometricShape(renderGroup), endHead);
+
+    if (isRenderGroup(renderGroup) && isValidEndHeadValue(endHead)) {
+        renderGroup->setEndHead(endHead);
+        return 0;
+    }
+
+    return -1;
+}
+
 int setEndHead(Transformation2D* transformation2D, const std::string endHead) {
-    if (isValidEndHeadValue(endHead)) {
-        if (isRenderGroup(transformation2D)) {
-            ((RenderGroup*)transformation2D)->setEndHead(endHead);
-            return 0;
-        }
-        else if (isRenderCurve(transformation2D)) {
-            ((RenderCurve*)transformation2D)->setEndHead(endHead);
-            return 0;
-        }
+    if (isRenderCurve(transformation2D) && isValidEndHeadValue(endHead)) {
+        ((RenderCurve*)transformation2D)->setEndHead(endHead);
+        return 0;
     }
 
     return -1;

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -3446,6 +3446,271 @@ bool isText(Transformation2D* shape) {
     return false;
 }
 
+bool isSetGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeColor(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeColor(getRenderGroup(style), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeColor(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+bool isSetGeometricShapeStrokeColor(Transformation2D* shape) {
+    if (isGraphicalPrimitive1D(shape))
+        return ((GraphicalPrimitive1D*)shape)->isSetStroke();
+
+    return false;
+}
+
+const std::string getGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeColor(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeColor(getRenderGroup(style), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeColor(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+const std::string getGeometricShapeStrokeColor(Transformation2D* shape) {
+    if (isGraphicalPrimitive1D(shape))
+        return ((GraphicalPrimitive1D*)shape)->getStroke();
+
+    return "";
+}
+
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(renderInformationBase, graphicalObject, 0, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(renderInformationBase, attribute, 0, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(getStyle(renderInformationBase, attribute), geometricShapeIndex, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(Style* style, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(style, 0, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(getRenderGroup(style), geometricShapeIndex, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(RenderGroup* renderGroup, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(renderGroup, 0, strokeColor);
+}
+
+int setGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    return setGeometricShapeStrokeColor(getGeometricShape(renderGroup, geometricShapeIndex), strokeColor);
+}
+
+int setGeometricShapeStrokeColor(Transformation2D* shape, const std::string& strokeColor) {
+    if (isValidColorValue(strokeColor)) {
+        if (isGraphicalPrimitive1D(shape)) {
+            ((GraphicalPrimitive1D*)shape)->setStroke(strokeColor);
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+bool isSetGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeWidth(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeWidth(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeWidth(getRenderGroup(style), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeStrokeWidth(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+bool isSetGeometricShapeStrokeWidth(Transformation2D* shape) {
+    if (isGraphicalPrimitive1D(shape))
+        return ((GraphicalPrimitive1D*)shape)->isSetStrokeWidth();
+
+    return false;
+}
+
+const double getGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeWidth(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+const double getGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeWidth(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+const double getGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeWidth(getRenderGroup(style), geometricShapeIndex);
+}
+
+const double getGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return getGeometricShapeStrokeWidth(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+const double getGeometricShapeStrokeWidth(Transformation2D* shape) {
+    if (isGraphicalPrimitive1D(shape))
+        return ((GraphicalPrimitive1D*)shape)->getStrokeWidth();
+
+    return -1;
+}
+
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(renderInformationBase, graphicalObject, 0, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(renderInformationBase, attribute, 0, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(getStyle(renderInformationBase, attribute), geometricShapeIndex, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(Style* style, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(style, 0, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(getRenderGroup(style), geometricShapeIndex, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(RenderGroup* renderGroup, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(renderGroup, 0, strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    return setGeometricShapeStrokeWidth(getGeometricShape(renderGroup, geometricShapeIndex), strokeWidth);
+}
+
+int setGeometricShapeStrokeWidth(Transformation2D* shape, const double& strokeWidth) {
+    if (isGraphicalPrimitive1D(shape)) {
+        ((GraphicalPrimitive1D*)shape)->setStrokeWidth(strokeWidth);
+        return 0;
+    }
+
+    return -1;
+}
+
+bool isSetGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeFillColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeFillColor(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeFillColor(getRenderGroup(style), geometricShapeIndex);
+}
+
+bool isSetGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeFillColor(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+bool isSetGeometricShapeFillColor(Transformation2D* shape) {
+    if (isGraphicalPrimitive2D(shape))
+        return ((GraphicalPrimitive2D*)shape)->isSetFillColor();
+
+    return false;
+}
+
+const std::string getGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    return getGeometricShapeFillColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex) {
+    return getGeometricShapeFillColor(getStyle(renderInformationBase, attribute), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex) {
+    return getGeometricShapeFillColor(getRenderGroup(style), geometricShapeIndex);
+}
+
+const std::string getGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex) {
+    return getGeometricShapeFillColor(getGeometricShape(renderGroup, geometricShapeIndex));
+}
+
+const std::string getGeometricShapeFillColor(Transformation2D* shape) {
+    if (isGraphicalPrimitive2D(shape))
+        return ((GraphicalPrimitive2D*)shape)->getFillColor();
+
+    return "";
+}
+
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& fillColor) {
+    return setGeometricShapeFillColor(renderInformationBase, graphicalObject, 0, fillColor);
+}
+
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    return setGeometricShapeFillColor(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex, fillColor);
+}
+
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& fillColor) {
+    return setGeometricShapeFillColor(renderInformationBase, attribute, 0, fillColor);
+}
+
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    return setGeometricShapeFillColor(getStyle(renderInformationBase, attribute), geometricShapeIndex, fillColor);
+}
+
+int setGeometricShapeFillColor(Style* style, const std::string& fillColor) {
+    return setGeometricShapeFillColor(style, 0, fillColor);
+}
+
+int setGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    return setGeometricShapeFillColor(getRenderGroup(style), geometricShapeIndex, fillColor);
+}
+
+int setGeometricShapeFillColor(RenderGroup* renderGroup, const std::string& fillColor) {
+    return setGeometricShapeFillColor(renderGroup, 0, fillColor);
+}
+
+int setGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    return setGeometricShapeFillColor(getGeometricShape(renderGroup, geometricShapeIndex), fillColor);
+}
+
+int setGeometricShapeFillColor(Transformation2D* shape, const std::string& fillColor) {
+    if (isValidColorValue(fillColor)) {
+        if (isGraphicalPrimitive2D(shape)) {
+            ((GraphicalPrimitive2D*)shape)->setFillColor(fillColor);
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
 bool isSetGeometricShapeX(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeX(getStyle(renderInformationBase, graphicalObject), geometricShapeIndex);
 }

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -1205,23 +1205,24 @@ int setReactionStrokeColor(GlobalRenderInformation* globalRenderInformation, con
 }
 
 int setSpeciesReferenceStrokeColor(GlobalRenderInformation* globalRenderInformation, const std::string& stroke) {
+    bool stokeColorIsSet = false;
     Style* style = getStyleByType(globalRenderInformation, getSpeciesReferenceGlyphStyleType());
     if (style) {
         addColor(globalRenderInformation, stroke);
-        if (setStrokeColor(style, stroke))
-            return -1;
+        if (!setStrokeColor(style, stroke))
+            stokeColorIsSet = true;
     }
     std::vector<std::pair<SpeciesReferenceRole_t, std::string>> styleRoles = getStyleRoles();
     for (unsigned int i = 0; i < styleRoles.size(); i++) {
         Style* style = getStyleByRole(globalRenderInformation, styleRoles[i].second);
         if (style) {
             addColor(globalRenderInformation, stroke);
-            if (setStrokeColor(style, stroke))
-                return -1;
+            if (!setStrokeColor(style, stroke))
+                stokeColorIsSet = true;
         }
     }
 
-    return -1;
+    return stokeColorIsSet ? 0 : -1;
 }
 
 bool isSetStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject) {

--- a/src/libsbmlnetwork_render.h
+++ b/src/libsbmlnetwork_render.h
@@ -2483,6 +2483,16 @@ LIBSBMLNETWORK_EXTERN int setFillColor(RenderGroup* renderGroup, const std::stri
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFillColor(Transformation2D* transformation2D, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& gradientId);
+
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& gradientId);
+
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(Style* style, const std::string& gradientId);
+
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(RenderGroup* renderGroup, const std::string& gradientId);
+
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(Transformation2D* transformation2D, const std::string& gradientId);
+
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for all CompartmentGlyph objects.
 /// @param globalRenderInformation a pointer to the GlobalRenderInformation object.
 /// @return the "fill" attribute of the RenderGroup of the Style for all CompartmentGlyph objects, or an empty string if the object is @c NULL.
@@ -2493,6 +2503,8 @@ LIBSBMLNETWORK_EXTERN const std::string getCompartmentFillColor(GlobalRenderInfo
 /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the Style for all CompartmentGlyph objects.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setCompartmentFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setCompartmentFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId);
 
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for all SpeciesGlyph objects.
 /// @param globalRenderInformation a pointer to the GlobalRenderInformation object.
@@ -2505,6 +2517,8 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesFillColor(GlobalRenderInformat
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId);
+
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for all ReactionGlyph objects.
 /// @param globalRenderInformation a pointer to the GlobalRenderInformation object.
 /// @return the "fill" attribute of the RenderGroup of the Style for all ReactionGlyph objects, or an empty string if the object is @c NULL.
@@ -2515,6 +2529,8 @@ LIBSBMLNETWORK_EXTERN const std::string getReactionFillColor(GlobalRenderInforma
 /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of the Style for all ReactionGlyph objects.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionFillColor(GlobalRenderInformation* globalRenderInformation, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setReactionFillColorAsGradient(GlobalRenderInformation* globalRenderInformation, const std::string& gradientId);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.
@@ -3804,6 +3820,24 @@ int setGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricS
 /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
 int setGeometricShapeFillColor(Transformation2D* shape, const std::string& fillColor);
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(Style* style, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(Style* style, unsigned int geometricShapeIndex, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(RenderGroup* renderGroup, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& gradientId);
+
+int setGeometricShapeFillColorAsGradient(Transformation2D* shape, const std::string& gradientId);
 
 /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.

--- a/src/libsbmlnetwork_render.h
+++ b/src/libsbmlnetwork_render.h
@@ -1120,6 +1120,8 @@ LIBSBMLNETWORK_EXTERN bool isSetStrokeColor(RenderInformationBase* renderInforma
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetStrokeColor(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetStrokeColor(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "stroke" attribute of this Transformation2D is set.
 /// @param transformation2D a pointer to the Transformation2D object.
 /// @return @c true if the "stroke" attribute of this Transformation2D object is set, @c false if either the "stroke"
@@ -1142,6 +1144,8 @@ LIBSBMLNETWORK_EXTERN const std::string getStrokeColor(RenderInformationBase* re
 /// @param style a pointer to the Style object.
 /// @return the "stroke" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getStrokeColor(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getStrokeColor(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "stroke" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1167,6 +1171,8 @@ LIBSBMLNETWORK_EXTERN int setStrokeColor(RenderInformationBase* renderInformatio
 /// @param stroke a string value to use as the value of the "stroke" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setStrokeColor(Style* style, const std::string& stroke);
+
+LIBSBMLNETWORK_EXTERN int setStrokeColor(RenderGroup* renderGroup, const std::string& stroke);
 
 /// @brief Sets the value of the "stroke" attribute of this Transformation2D object.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1237,6 +1243,8 @@ LIBSBMLNETWORK_EXTERN bool isSetStrokeWidth(RenderInformationBase* renderInforma
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetStrokeWidth(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetStrokeWidth(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "stroke-width" attribute of this Transformation2D is set.
 /// @param transformation2D a pointer to the Transformation2D object.
 /// @return @c true if the "stroke-width" attribute of this Transformation2D object is set, @c false if either the "stroke-width"
@@ -1259,6 +1267,8 @@ LIBSBMLNETWORK_EXTERN const double getStrokeWidth(RenderInformationBase* renderI
 /// @param style a pointer to the Style object.
 /// @return the "stroke-width" attribute of the RenderGroup of this Style object, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getStrokeWidth(Style* style);
+
+LIBSBMLNETWORK_EXTERN const double getStrokeWidth(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "stroke-width" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1284,6 +1294,8 @@ LIBSBMLNETWORK_EXTERN int setStrokeWidth(RenderInformationBase* renderInformatio
 /// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setStrokeWidth(Style* style, const double& strokeWidth);
+
+LIBSBMLNETWORK_EXTERN int setStrokeWidth(RenderGroup* renderGroup, const double& strokeWidth);
 
 /// @brief Sets the value of the "stroke-width" attribute of this Transformation2D object.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1350,6 +1362,8 @@ LIBSBMLNETWORK_EXTERN bool isSetStrokeDashArray(RenderInformationBase* renderInf
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetStrokeDashArray(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetStrokeDashArray(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of this Transformation2D is set.
 /// @param transformation2D a pointer to the Transformation2D object.
 /// @return @c true if the "stroke-dasharray" attribute of this Transformation2D object is set, @c false if either the "stroke-dasharray"
@@ -1372,6 +1386,8 @@ LIBSBMLNETWORK_EXTERN const std::vector<unsigned int> getStrokeDashArray(RenderI
 /// @param style a pointer to the Style object.
 /// @return the "stroke-dasharray" attribute of the RenderGroup of this Style object, or an empty vector if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::vector<unsigned int> getStrokeDashArray(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::vector<unsigned int> getStrokeDashArray(RenderGroup* renderGroup);
 
 /// @brief Returns the vector of the "stroke-dasharray" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1398,6 +1414,8 @@ LIBSBMLNETWORK_EXTERN int setStrokeDashArray(RenderInformationBase* renderInform
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setStrokeDashArray(Style* style, const std::vector<unsigned int>& strokeDashArray);
 
+LIBSBMLNETWORK_EXTERN int setStrokeDashArray(RenderGroup* renderGroup, const std::vector<unsigned int>& strokeDashArray);
+
 /// @brief Sets the value of the "stroke-dasharray" of this GraphicalPrimitive1D object.
 /// @param shape a pointer to the Transformation2D object.
 /// @param strokeDashArray a vector to use as the value  of the "stroke-dasharray" attribute of this GraphicalPrimitive1D object.
@@ -1420,6 +1438,8 @@ LIBSBMLNETWORK_EXTERN unsigned int getNumStrokeDashes(RenderInformationBase* ren
 /// @param style a pointer to the Style object.
 /// @return the size of the "stroke-dasharray" attribute of the RenderGroup of this Style object, or @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getNumStrokeDashes(Style* style);
+
+LIBSBMLNETWORK_EXTERN unsigned int getNumStrokeDashes(RenderGroup* renderGroup);
 
 /// @brief Returns the size of the "stroke-dasharray" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1445,6 +1465,8 @@ LIBSBMLNETWORK_EXTERN unsigned int getStrokeDash(RenderInformationBase* renderIn
 /// @param strokeDashIndex an unsigned int representing the index of the dash to retrieve.
 /// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup of this Style object, or @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getStrokeDash(Style* style, unsigned int strokeDashIndex = 0);
+
+LIBSBMLNETWORK_EXTERN unsigned int getStrokeDash(RenderGroup* renderGroup, unsigned int strokeDashIndex = 0);
 
 /// @brief Returns the stroke dash at the given index of the 'stroke-dasharray' attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1495,6 +1517,8 @@ LIBSBMLNETWORK_EXTERN int setStrokeDash(Style* style, unsigned int dash);
 /// @param dash a unsigned int value to use as the dash at the given index of the 'stroke-dasharray' attribute of of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setStrokeDash(Style* style, unsigned int strokeDashIndex, unsigned int dash);
+
+LIBSBMLNETWORK_EXTERN int setStrokeDash(RenderGroup* renderGroup, unsigned int dash);
 
 /// @brief Sets the first dash of the 'stroke-dasharray' attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -1547,6 +1571,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFontColor(RenderInformationBase* renderInformati
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFontColor(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFontColor(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "stroke" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "stroke" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "stroke"
@@ -1569,6 +1595,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFontColor(RenderInformationBase* rend
 /// @param style a pointer to the Style object.
 /// @return the "stroke" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFontColor(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFontColor(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "stroke" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1594,6 +1622,8 @@ LIBSBMLNETWORK_EXTERN int setFontColor(RenderInformationBase* renderInformationB
 /// @param fontColor a string value to use as the value of the "stroke" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontColor(Style* style, const std::string& fontColor);
+
+LIBSBMLNETWORK_EXTERN int setFontColor(RenderGroup* renderGroup, const std::string& fontColor);
 
 /// @brief Sets the value of the "stroke" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1654,6 +1684,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFontFamily(RenderInformationBase* renderInformat
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFontFamily(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFontFamily(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "font-family" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "font-family" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "font-family"
@@ -1676,6 +1708,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFontFamily(RenderInformationBase* ren
 /// @param style a pointer to the Style object.
 /// @return the "font-family" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFontFamily(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFontFamily(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "font-family" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1701,6 +1735,8 @@ LIBSBMLNETWORK_EXTERN int setFontFamily(RenderInformationBase* renderInformation
 /// @param fontFamily a string value to use as the value of the "font-family" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontFamily(Style* style, const std::string& fontFamily);
+
+LIBSBMLNETWORK_EXTERN int setFontFamily(RenderGroup* renderGroup, const std::string& fontFamily);
 
 /// @brief Sets the value of the "font-family" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1761,6 +1797,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFontSize(RenderInformationBase* renderInformatio
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFontSize(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFontSize(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "font-size" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "font-size" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "font-size"
@@ -1783,6 +1821,8 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getFontSize(RenderInformationBase* rend
 /// @param style a pointer to the Style object.
 /// @return the "font-size" attribute of the RenderGroup of this Style object, or @c RelAbsVector() if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const RelAbsVector getFontSize(Style* style);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getFontSize(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "font-size" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1809,6 +1849,8 @@ LIBSBMLNETWORK_EXTERN int setFontSize(RenderInformationBase* renderInformationBa
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontSize(Style* style, const RelAbsVector& fontSize);
 
+LIBSBMLNETWORK_EXTERN int setFontSize(RenderGroup* renderGroup, const RelAbsVector& fontSize);
+
 /// @brief Sets the value of the "font-size" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @param fontSize a RelAbsVector to use as the value of the "font-size" attribute of this Transformation2D (Text or RenderGroup) object.
@@ -1834,6 +1876,8 @@ LIBSBMLNETWORK_EXTERN int setFontSizeAsDouble(RenderInformationBase* renderInfor
 /// @param fontSize a double value to use as the value of the "font-size" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontSizeAsDouble(Style* style, const double& fontSize);
+
+LIBSBMLNETWORK_EXTERN int setFontSizeAsDouble(RenderGroup* renderGroup, const double& fontSize);
 
 /// @brief Sets the value of the "font-size" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1927,6 +1971,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFontWeight(RenderInformationBase* renderInformat
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFontWeight(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFontWeight(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "font-weight" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "font-weight" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "font-weight"
@@ -1949,6 +1995,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFontWeight(RenderInformationBase* ren
 /// @param style a pointer to the Style object.
 /// @return the "font-weight" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFontWeight(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFontWeight(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "font-weight" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -1974,6 +2022,8 @@ LIBSBMLNETWORK_EXTERN int setFontWeight(RenderInformationBase* renderInformation
 /// @param fontWeight a string value to use as the value of the "font-weight" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontWeight(Style* style, const std::string& fontWeight);
+
+LIBSBMLNETWORK_EXTERN int setFontWeight(RenderGroup* renderGroup, const std::string& fontWeight);
 
 /// @brief Sets the value of the "font-weight" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2034,6 +2084,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFontStyle(RenderInformationBase* renderInformati
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFontStyle(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFontStyle(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "font-style" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "font-style" attribute of this GraphicalPrimitive1D (Text or RenderGroup) object is set, @c false if either the "font-style"
@@ -2056,6 +2108,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFontStyle(RenderInformationBase* rend
 /// @param style a pointer to the Style object.
 /// @return the "font-style" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFontStyle(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFontStyle(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "font-style" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2081,6 +2135,8 @@ LIBSBMLNETWORK_EXTERN int setFontStyle(RenderInformationBase* renderInformationB
 /// @param fontStyle a string value to use as the value of the "font-style" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFontStyle(Style* style, const std::string& fontStyle);
+
+LIBSBMLNETWORK_EXTERN int setFontStyle(RenderGroup* renderGroup, const std::string& fontStyle);
 
 /// @brief Sets the value of the "font-style" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2141,6 +2197,8 @@ LIBSBMLNETWORK_EXTERN bool isSetTextAnchor(RenderInformationBase* renderInformat
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetTextAnchor(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetTextAnchor(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "text-anchor" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "text-anchor" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "text-anchor"
@@ -2163,6 +2221,8 @@ LIBSBMLNETWORK_EXTERN const std::string getTextAnchor(RenderInformationBase* ren
 /// @param style a pointer to the Style object.
 /// @return the "text-anchor" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getTextAnchor(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getTextAnchor(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "text-anchor" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2188,6 +2248,8 @@ LIBSBMLNETWORK_EXTERN int setTextAnchor(RenderInformationBase* renderInformation
 /// @param textAnchor a string value to use as the value of the "text-anchor" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setTextAnchor(Style* style, const std::string& textAnchor);
+
+LIBSBMLNETWORK_EXTERN int setTextAnchor(RenderGroup* renderGroup, const std::string& textAnchor);
 
 /// @brief Sets the value of the "text-anchor" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2248,6 +2310,8 @@ LIBSBMLNETWORK_EXTERN bool isSetVTextAnchor(RenderInformationBase* renderInforma
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetVTextAnchor(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetVTextAnchor(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "vtext-anchor" attribute of this Transformation2D (Text or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
 /// @return @c true if the "vtext-anchor" attribute of this Transformation2D (Text or RenderGroup) object is set, @c false if either the "vtext-anchor"
@@ -2270,6 +2334,8 @@ LIBSBMLNETWORK_EXTERN const std::string getVTextAnchor(RenderInformationBase* re
 /// @param style a pointer to the Style object.
 /// @return the "vtext-anchor" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getVTextAnchor(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getVTextAnchor(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "vtext-anchor" attribute of this Transformation2D (Text or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2295,6 +2361,8 @@ LIBSBMLNETWORK_EXTERN int setVTextAnchor(RenderInformationBase* renderInformatio
 /// @param vtextAnchor a string value to use as the value of the "vtext-anchor" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setVTextAnchor(Style* style, const std::string& vtextAnchor);
+
+LIBSBMLNETWORK_EXTERN int setVTextAnchor(RenderGroup* renderGroup, const std::string& vtextAnchor);
 
 /// @brief Sets the value of the "vtext-anchor" attribute of this Transformation2D (Text or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D (Text or RenderGroup) object.
@@ -2355,6 +2423,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFillColor(RenderInformationBase* renderInformati
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFillColor(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFillColor(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "fill" attribute of this Transformation2D is set.
 /// @param transformation2D a pointer to the Transformation2D object.
 /// @return @c true if the "fill" attribute of this Transformation2D object is set, @c false if either the "fill"
@@ -2377,6 +2447,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFillColor(RenderInformationBase* rend
 /// @param style a pointer to the Style object.
 /// @return the "fill" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFillColor(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFillColor(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "fill" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2402,6 +2474,8 @@ LIBSBMLNETWORK_EXTERN int setFillColor(RenderInformationBase* renderInformationB
 /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFillColor(Style* style, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setFillColor(RenderGroup* renderGroup, const std::string& fillColor);
 
 /// @brief Sets the value of the "fill" attribute of this Transformation2D object.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2462,6 +2536,8 @@ LIBSBMLNETWORK_EXTERN bool isSetFillRule(RenderInformationBase* renderInformatio
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetFillRule(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetFillRule(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "fill-rule" attribute of this Transformation2D is set.
 /// @param transformation2D a pointer to the Transformation2D object.
 /// @return @c true if the "fill-rule" attribute of this Transformation2D object is set, @c false if either the "fill-rule"
@@ -2484,6 +2560,8 @@ LIBSBMLNETWORK_EXTERN const std::string getFillRule(RenderInformationBase* rende
 /// @param style a pointer to the Style object.
 /// @return the "fill-rule" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getFillRule(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getFillRule(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "fill-rule" attribute of this Transformation2D.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2509,6 +2587,8 @@ LIBSBMLNETWORK_EXTERN int setFillRule(RenderInformationBase* renderInformationBa
 /// @param fillRule a string value to use as the value of the "fill-rule" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFillRule(Style* style, const std::string& fillRule);
+
+LIBSBMLNETWORK_EXTERN int setFillRule(RenderGroup* renderGroup, const std::string& fillRule);
 
 /// @brief Sets the value of the "fill-rule" attribute of this Transformation2D object.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2569,6 +2649,8 @@ LIBSBMLNETWORK_EXTERN bool isSetStartHead(RenderInformationBase* renderInformati
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetStartHead(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetStartHead(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "startHead" attribute of this Transformation2D (RenderCurve or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (RenderCurve or RenderGroup) object.
 /// @return @c true if the "startHead" attribute of this Transformation2D (RenderCurve or RenderGroup) object is set, @c false if either the "startHead" attribute is not set or the object is @c NULL .
@@ -2590,6 +2672,8 @@ LIBSBMLNETWORK_EXTERN const std::string getStartHead(RenderInformationBase* rend
 /// @param style a pointer to the Style object.
 /// @return the "startHead" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getStartHead(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getStartHead(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "startHead" attribute of this Transformation2D (RenderCurve or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D (RenderCurve or RenderGroup) object.
@@ -2615,6 +2699,8 @@ LIBSBMLNETWORK_EXTERN int setStartHead(RenderInformationBase* renderInformationB
 /// @param startHead a string value to use as the value of the "startHead" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setStartHead(Style* style, const std::string& startHead);
+
+LIBSBMLNETWORK_EXTERN int setStartHead(RenderGroup* renderGroup, const std::string& startHead);
 
 /// @brief Sets the value of the "startHead" attribute of this Transformation2D (RenderCurve or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2642,6 +2728,8 @@ LIBSBMLNETWORK_EXTERN bool isSetEndHead(RenderInformationBase* renderInformation
 /// attribute is not set or the object is @c NULL .
 LIBSBMLNETWORK_EXTERN bool isSetEndHead(Style* style);
 
+LIBSBMLNETWORK_EXTERN bool isSetEndHead(RenderGroup* renderGroup);
+
 /// @brief Predicates returning @c true if the "endHead" attribute of this Transformation2D (RenderCurve or RenderGroup) is set.
 /// @param transformation2D a pointer to the Transformation2D (RenderCurve or RenderGroup) object.
 /// @return @c true if the "endHead" attribute of this Transformation2D (RenderCurve or RenderGroup) object is set, @c false if either the "endHead" attribute is not set or the object is @c NULL .
@@ -2663,6 +2751,8 @@ LIBSBMLNETWORK_EXTERN const std::string getEndHead(RenderInformationBase* render
 /// @param style a pointer to the Style object.
 /// @return the "endHead" attribute of the RenderGroup of this Style object, or @c "" if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getEndHead(Style* style);
+
+LIBSBMLNETWORK_EXTERN const std::string getEndHead(RenderGroup* renderGroup);
 
 /// @brief Returns the value of the "endHead" attribute of this Transformation2D (RenderCurve or RenderGroup).
 /// @param transformation2D a pointer to the Transformation2D object.
@@ -2688,6 +2778,8 @@ LIBSBMLNETWORK_EXTERN int setEndHead(RenderInformationBase* renderInformationBas
 /// @param endHead a string value to use as the value of the "endHead" attribute of the RenderGroup of this Style object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setEndHead(Style* style, const std::string& endHead);
+
+LIBSBMLNETWORK_EXTERN int setEndHead(RenderGroup* renderGroup, const std::string& endHead);
 
 /// @brief Sets the value of the "endHead" attribute of this Transformation2D (RenderCurve or RenderGroup) object.
 /// @param transformation2D a pointer to the Transformation2D object.

--- a/src/libsbmlnetwork_render.h
+++ b/src/libsbmlnetwork_render.h
@@ -3347,6 +3347,372 @@ LIBSBMLNETWORK_EXTERN bool isText(RenderGroup* renderGroup, unsigned int geometr
 /// @return @c true if this abstract Transformation2D is of type Text, @c false if either it is not of type Text or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isText(Transformation2D* shape);
 
+/// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if
+/// it is not set or is or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of this RenderGroup is set.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D at the given index of this RenderGroup is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke" attribute of this abstract Transformation2D is set.
+/// @param shape a pointer to the Transformation2D object.
+/// @return @c true if the "stroke" attribute of this abstract Transformation2D is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(Transformation2D* shape);
+
+/// @brief Retrieves the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const std::string getGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const std::string getGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+const std::string getGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "stroke" attribute of the Transformation2D at the given index of this RenderGroup.
+const std::string getGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @return a string value representing the "stroke" attribute of this abstract Transformation2D.
+const std::string getGeometricShapeStrokeColor(Transformation2D* shape);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(Style* style, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(Style* style, unsigned int geometricShapeIndex, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderGroup* renderGroup, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& StrokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @param StrokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(Transformation2D* shape, const std::string& StrokeColor);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of this RenderGroup is set.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke-width" attribute of the Transformation2D at the given index of this RenderGroup is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of this abstract Transformation2D is set.
+/// @param shape a pointer to the Transformation2D object.
+/// @return @c true if the "stroke-width" attribute of this abstract Transformation2D is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(Transformation2D* shape);
+
+/// @brief Retrieves the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a double value representing the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const double getGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a double value representing the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const double getGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a double value representing the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+const double getGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke-width" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a double value representing the "stroke-width" attribute of the Transformation2D at the given index of this RenderGroup.
+const double getGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "stroke-width" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @return a double value representing the "stroke-width" attribute of this abstract Transformation2D.
+const double getGeometricShapeStrokeWidth(Transformation2D* shape);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(Style* style, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(Style* style, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderGroup* renderGroup, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(Transformation2D* shape, const double& strokeWidth);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of this RenderGroup is set.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D at the given index of this RenderGroup is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "fill" attribute of this abstract Transformation2D is set.
+/// @param shape a pointer to the Transformation2D object.
+/// @return @c true if the "fill" attribute of this abstract Transformation2D is set, @c false if it is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(Transformation2D* shape);
+
+/// @brief Retrieves the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const std::string getGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+const std::string getGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+const std::string getGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "fill" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return a string value representing the "fill" attribute of the Transformation2D at the given index of this RenderGroup.
+const std::string getGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex);
+
+/// @brief Retrieves the value of the "fill" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @return a string value representing the "fill" attribute of this abstract Transformation2D.
+const std::string getGeometricShapeFillColor(Transformation2D* shape);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param renderInformationBase a pointer to the RenderInformationBase object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderInformationBase* renderInformationBase, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(Style* style, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of this Style.
+/// @param style a pointer to the Style object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(Style* style, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of this RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderGroup* renderGroup, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup.
+/// @param renderGroup a pointer to the RenderGroup object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(RenderGroup* renderGroup, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of this abstract Transformation2D.
+/// @param shape a pointer to the Transformation2D object.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(Transformation2D* shape, const std::string& fillColor);
+
 /// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param renderInformationBase a pointer to the RenderInformationBase object.
 /// @param graphicalObject a pointer to the GraphicalObject object.

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -294,7 +294,10 @@ const std::string addColor(RenderInformationBase* renderInformationBase, const s
 }
 
 const std::string addColor(RenderInformationBase* renderInformationBase, const std::string &colorId, const std::string &colorValue) {
-    if (!colorId.empty() && !colorValue.empty() && !renderInformationBase->getColorDefinition(colorId)) {
+    if (stringCompare(getColorValue(renderInformationBase, colorId), colorValue))
+        return colorId;
+
+    if (!colorId.empty() && !colorValue.empty()) {
         RenderPkgNamespaces* renderPkgNamespaces = new RenderPkgNamespaces(renderInformationBase->getLevel(), renderInformationBase->getVersion());
         if (!renderInformationBase->addColorDefinition(createColorDefinition(renderPkgNamespaces, toLowerCase(colorId), colorValue)))
             return toLowerCase(colorId);

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -304,6 +304,7 @@ const std::string addColor(RenderInformationBase* renderInformationBase, const s
             delete cd;
             return toLowerCase(colorId);
         }
+    }
 
     return "";
 }

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -225,6 +225,25 @@ void addColorsOfDefaultGeometricShapes(GlobalRenderInformation* globalRenderInfo
     addColor(globalRenderInformation, "black");
 }
 
+const std::string getColorValue(RenderInformationBase* renderInformationBase, const std::string &colorId) {
+    ColorDefinition* colorDefinition = renderInformationBase->getColorDefinition(colorId);
+    if (colorDefinition)
+        return colorDefinition->getValue();
+
+    return "";
+}
+
+const std::string getColorId(RenderInformationBase* renderInformationBase, const std::string &colorValue) {
+    for (unsigned int i = 0; i < renderInformationBase->getNumColorDefinitions(); i++) {
+        ColorDefinition* colorDefinition = renderInformationBase->getColorDefinition(i);
+        if (stringCompare(colorDefinition->getValue(), colorValue))
+            return colorDefinition->getId();
+    }
+
+    return "";
+}
+
+
 const bool addColor(SBMLDocument* document, Style* style, const std::string &color) {
     if (style) {
         for (unsigned int i = 0; i < getNumLocalRenderInformation(document); i++) {
@@ -285,11 +304,14 @@ const bool addColor(RenderInformationBase* renderInformationBase, const std::str
 }
 
 const std::string getColorIdFromHexColorCode(RenderInformationBase* renderInformationBase, const std::string &hexColorCode) {
-    std::string colorId = getHtmlColorNameFromHexColorCode(hexColorCode);
-    if (colorId.empty())
-        colorId = getUniqueColorId(renderInformationBase);
+    std::string colorId = getColorId(renderInformationBase, hexColorCode);
+    if (!colorId.empty())
+        return colorId;
+    colorId = getHtmlColorNameFromHexColorCode(hexColorCode);
+    if (!colorId.empty())
+        return colorId;
 
-    return colorId;
+    return getUniqueColorId(renderInformationBase);
 }
 
 const std::string getUniqueColorId(RenderInformationBase* renderInformationBase) {

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -1044,7 +1044,7 @@ const bool canHaveStrokeDashArray(GraphicalObject* graphicalObject) {
 }
 
 const bool canHaveFillColor(GraphicalObject* graphicalObject) {
-    if (isCompartmentGlyph(graphicalObject) || isSpeciesGlyph(graphicalObject) || (isReactionGlyph(graphicalObject) && !getCurve(graphicalObject)))
+    if (isCompartmentGlyph(graphicalObject) || isSpeciesGlyph(graphicalObject) || isReactionGlyph(graphicalObject))
         return true;
 
     return false;

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -333,6 +333,46 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
     return colorDefinition;
 }
 
+LineEnding* createLocalLineEnding(SBMLDocument* document, RenderInformationBase* localRenderInformation, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    LineEnding* localLineEnding = NULL;
+    std::string localLineEndingId = getLocalLineEndingId(document, speciesReferenceGlyph);
+    if (localRenderInformation && !localLineEndingId.empty()) {
+        localLineEnding = ((LocalRenderInformation*)localRenderInformation)->createLineEnding();
+        localLineEnding->setId(localLineEndingId);
+        if (isSetStartHead(document, speciesReferenceGlyph))
+            setStartHead(document, speciesReferenceGlyph, localLineEndingId);
+        else if (isSetEndHead(document, speciesReferenceGlyph))
+            setEndHead(document, speciesReferenceGlyph, localLineEndingId);
+    }
+
+    return localLineEnding;
+}
+
+const bool isLocal(SBMLDocument* document, LineEnding* lineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    if (!lineEnding || !speciesReferenceGlyph)
+        return false;
+
+    std::string localLineEndingId = getLocalLineEndingId(document, speciesReferenceGlyph);
+    if (localLineEndingId.empty())
+        return false;
+
+    return lineEnding->getId() == localLineEndingId;
+}
+
+const std::string getLocalLineEndingId(SBMLDocument* document, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    std::string globalLineEndingId = getStartHead(document, speciesReferenceGlyph);
+    if (globalLineEndingId.empty())
+        globalLineEndingId = getEndHead(document, speciesReferenceGlyph);
+    if (!globalLineEndingId.empty()) {
+        if (globalLineEndingId.find(speciesReferenceGlyph->getId()) != std::string::npos)
+            return globalLineEndingId;
+
+        return speciesReferenceGlyph->getId() + "_" + globalLineEndingId;
+    }
+
+    return "";
+}
+
 void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation) {
     addProductHeadLineEnding(globalRenderInformation);
     addModifierHeadLineEnding(globalRenderInformation);

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -71,13 +71,19 @@ const std::string getColorValue(RenderInformationBase* renderInformationBase, co
 
 const std::string getColorId(RenderInformationBase* renderInformationBase, const std::string &colorValue);
 
-const bool addColor(SBMLDocument* document, Style* style, const std::string &color);
+const std::string addColor(SBMLDocument* document, Style* style, const std::string &color);
 
-const bool addColor(SBMLDocument* document, LineEnding* lineEnding, const std::string &color);
+const std::string addColor(SBMLDocument* document, LineEnding* lineEnding, const std::string &color);
 
-const bool addColor(RenderInformationBase* renderInformationBase, const std::string &color);
+const std::string addColor(RenderInformationBase* renderInformationBase, const std::string &color);
 
-const bool addColor(RenderInformationBase* renderInformationBase, const std::string &colorId, const std::string &colorValue);
+const std::string addColor(RenderInformationBase* renderInformationBase, const std::string &colorId, const std::string &colorValue);
+
+const std::string addGradient(SBMLDocument* document, Style* style, const std::string type, std::vector<std::pair<std::string, double>> stopsVector);
+
+const std::string addGradient(SBMLDocument* document, LineEnding* lineEnding, const std::string type, std::vector<std::pair<std::string, double>> stopsVector);
+
+const std::string addGradient(RenderInformationBase* renderInformationBase, const std::string type, std::vector<std::pair<std::string, double>> stopsVector);
 
 const std::string getColorIdFromHexColorCode(RenderInformationBase* renderInformationBase, const std::string &hexColorCode);
 
@@ -86,6 +92,16 @@ const std::string getUniqueColorId(RenderInformationBase* renderInformationBase)
 ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 
 ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, const std::string &value);
+
+GradientBase* createGradient(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, const std::string type, std::vector<std::pair<std::string, double>> stopsVector);
+
+GradientBase* createLinearGradient(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, std::vector<std::pair<std::string, double>> stopsVector);
+
+GradientBase* createRadialGradient(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, std::vector<std::pair<std::string, double>> stopsVector);
+
+GradientStop* createGradientStop(RenderPkgNamespaces* renderPkgNamespaces, const std::string &stopColor, const RelAbsVector& offset);
+
+const std::string getUniqueGradientId(RenderInformationBase* renderInformationBase);
 
 LineEnding* createLocalLineEnding(RenderInformationBase* localRenderInformation, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
@@ -252,6 +268,8 @@ const bool canHaveGeometricShape(GraphicalObject* graphicalObject);
 const bool isValidBackgroundColorValue(const std::string& backgroundColor);
 
 const bool isValidSpreadMethodValue(const std::string& spreadMethod);
+
+const bool isValidGradientStopsVector(std::vector<std::pair<std::string, double>> gradientStopsVector);
 
 const bool isValidOffsetValue(const RelAbsVector& offset);
 

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -67,6 +67,10 @@ void addColorsOfDefaultGeometricShapes(SBMLDocument* document, Style* style);
 
 void addColorsOfDefaultGeometricShapes(GlobalRenderInformation* globalRenderInformation);
 
+const std::string getColorValue(RenderInformationBase* renderInformationBase, const std::string &colorId);
+
+const std::string getColorId(RenderInformationBase* renderInformationBase, const std::string &colorValue);
+
 const bool addColor(SBMLDocument* document, Style* style, const std::string &color);
 
 const bool addColor(SBMLDocument* document, LineEnding* lineEnding, const std::string &color);

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -87,7 +87,13 @@ ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces,
 
 ColorDefinition* createColorDefinition(RenderPkgNamespaces* renderPkgNamespaces, const std::string &id, const std::string &value);
 
-void addTextGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
+LineEnding* createLocalLineEnding(RenderInformationBase* localRenderInformation, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
+LineEnding* createLocalLineEnding(SBMLDocument* document, RenderInformationBase* localRenderInformation, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
+const bool isLocal(SBMLDocument* document, LineEnding* lineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
+const std::string getLocalLineEndingId(SBMLDocument* document, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
 void addDefaultLineEndings(GlobalRenderInformation* globalRenderInformation);
 

--- a/src/libsbmlnetwork_sbmldocument.cpp
+++ b/src/libsbmlnetwork_sbmldocument.cpp
@@ -97,10 +97,11 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return -1;
     }
 
-    int distribute(SBMLDocument* document, std::set <std::string> nodeIds, const std::string& direction, const double& spacing) {
+    int distribute(SBMLDocument* document, std::set <std::pair<std::string, unsigned int>> nodeIds, const std::string& direction, const double spacing) {
         if (nodeIds.size() > 1) {
             std::vector<GraphicalObject*> allGraphicalObjects;
-            for (std::set<std::string>::const_iterator nodeIt = nodeIds.cbegin(); nodeIt != nodeIds.cend(); nodeIt++) {
+            std::vector<std::string> sortedNodeIdsVector = getSortedNodeIdsVector(nodeIds);
+            for (std::vector<std::string>::const_iterator nodeIt = sortedNodeIdsVector.cbegin(); nodeIt != sortedNodeIdsVector.cend(); nodeIt++) {
                 std::vector<GraphicalObject*> graphicalObjects = getGraphicalObjects(document, *nodeIt);
                 allGraphicalObjects.insert(allGraphicalObjects.end(), graphicalObjects.begin(), graphicalObjects.end());
             }

--- a/src/libsbmlnetwork_sbmldocument.cpp
+++ b/src/libsbmlnetwork_sbmldocument.cpp
@@ -74,9 +74,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return -1;
     }
 
-    int autorender(SBMLDocument* document) {
+    int autorender(SBMLDocument* document, const int maxNumConnectedEdges) {
         if (!getNumLayouts(document))
-            createDefaultLayoutFeatures(document);
+            createDefaultLayoutFeatures(document, maxNumConnectedEdges);
         if (getNumLayouts(document))
             return createDefaultRenderInformation(document);
 

--- a/src/libsbmlnetwork_sbmldocument.h
+++ b/src/libsbmlnetwork_sbmldocument.h
@@ -86,11 +86,11 @@ LIBSBMLNETWORK_EXTERN int align(SBMLDocument* document, std::set<std::string> no
 
 /// @brief Distribute the nodes position in the SBML document in the given distribution direction.
 /// @param document a pointer to the SBMLDocument object.
-/// @param nodeIds a set of node ids to be distributed.
+/// @param nodeIds a set of node ids and their order to be distributed.
 /// @param direction determines how to distribute the nodes.
 /// @param spacing the spacing between the distributed nodes.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int distribute(SBMLDocument* document, std::set<std::string> nodeIds, const std::string& direction, const double& spacing = -1);
+LIBSBMLNETWORK_EXTERN int distribute(SBMLDocument* document, std::set <std::pair<std::string, unsigned int>> nodeIds, const std::string& direction, const double spacing = -1);
 
 /// @brief Returns the first child element found that has the given id in the model-wide SId namespace, or NULL if no such object is found.
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument.h
+++ b/src/libsbmlnetwork_sbmldocument.h
@@ -73,8 +73,9 @@ LIBSBMLNETWORK_EXTERN int autolayout(SBMLDocument* document, const int maxNumCon
 
 /// @brief Create a Render object and add it to the the SBML document if it does not exist.
 /// @param document a pointer to the SBMLDocument object.
+/// @param maxNumConnectedEdges the maximum number of connected edges before creating an alias SpeciesGlyph.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int autorender(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN int autorender(SBMLDocument* document, const int maxNumConnectedEdges = 3);
 
 /// @brief Align the nodes position in the SBML document in the given alignment type.
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -848,6 +848,42 @@ LineEnding* getLineEnding(SBMLDocument* document, unsigned int renderIndex, unsi
     return getLineEnding(getLocalRenderInformation(document, 0, renderIndex), lineEndingIndex);
 }
 
+LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    LineEnding* localLineEnding = createLocalLineEnding(document, getLocalRenderInformation(document), speciesReferenceGlyph);
+    if (localLineEnding && globalLineEnding) {
+        localLineEnding->setGroup(globalLineEnding->getGroup()->clone());
+        localLineEnding->setBoundingBox(globalLineEnding->getBoundingBox()->clone());
+    }
+
+    return localLineEnding;
+}
+
+LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    LineEnding* lineEnding = getLineEnding(document, getStartHead(document, speciesReferenceGlyph));
+    if (!lineEnding)
+        lineEnding = getLineEnding(document, getEndHead(document, speciesReferenceGlyph));
+
+    return lineEnding;
+}
+
+LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLocalLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    LineEnding* lineEnding = getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    if(!isLocal(document, lineEnding, speciesReferenceGlyph))
+        lineEnding = createLocalLineEnding(document, lineEnding, speciesReferenceGlyph);
+
+    return lineEnding;
+}
+
 bool isSetEnableRotationalMapping(SBMLDocument* document, const std::string& sid) {
     return isSetEnableRotationalMapping(getLineEnding(document, sid));
 }
@@ -880,12 +916,28 @@ BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int rende
     return getLineEndingBoundingBox(getLineEnding(document, renderIndex, sid));
 }
 
+BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingBoundingBox(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getLineEndingBoundingBox(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+}
+
 const double getLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid) {
     return getPositionX(getLineEndingBoundingBox(document, sid));
 }
 
 const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid) {
     return getPositionX(getLineEndingBoundingBox(document, renderIndex, sid));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid, double x) {
@@ -896,12 +948,28 @@ int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionX(getLineEndingBoundingBox(document, renderIndex, sid), x);
 }
 
+int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+    return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
+}
+
+int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+    return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
+}
+
 const double getLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid) {
     return getPositionY(getLineEndingBoundingBox(document, sid));
 }
 
 const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid) {
     return getPositionY(getLineEndingBoundingBox(document, renderIndex, sid));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid, double y) {
@@ -912,12 +980,30 @@ int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionY(getLineEndingBoundingBox(document, renderIndex, sid), y);
 }
 
+int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+    return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
+}
+
+int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+    return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
+}
+
 const double getLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid) {
     return getDimensionWidth(getLineEndingBoundingBox(document, sid));
 }
 
 const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid) {
     return getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+                                                                      speciesReferenceIndex));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+                                                                      speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid, double width) {
@@ -928,6 +1014,14 @@ int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderInd
     return setDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid), width);
 }
 
+int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+    return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
+}
+
+int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+    return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
+}
+
 const double getLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid) {
     return getDimensionHeight(getLineEndingBoundingBox(document, sid));
 }
@@ -936,12 +1030,30 @@ const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int
     return getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
+const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+                                                                       speciesReferenceIndex));
+}
+
+const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+                                                                       speciesReferenceIndex));
+}
+
 int setLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid, double height) {
     return setDimensionHeight(getLineEndingBoundingBox(document, sid), height);
 }
 
 int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double height) {
     return setDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid), height);
+}
+
+int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+    return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
+}
+
+int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+    return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
 }
 
 RenderGroup* getLineEndingRenderGroup(SBMLDocument* document, const std::string& sid) {
@@ -953,274 +1065,284 @@ RenderGroup* getLineEndingRenderGroup(SBMLDocument* document, unsigned int rende
 }
 
 bool isSetLineEndingStrokeColor(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && isSetStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, id))))
-        return isSetStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, id)));
-
     return isSetStrokeColor(getLineEndingRenderGroup(document, id));
 }
 
 bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && isSetStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))))
-       return isSetStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return isSetStrokeColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getLineEndingStrokeColor(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && !getStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, id))).empty())
-        return getStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, id)));
+bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+const std::string getLineEndingStrokeColor(SBMLDocument* document, const std::string& id) {
     return getStrokeColor(getLineEndingRenderGroup(document, id));
 }
 
 const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && !getStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))).empty())
-        return getStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getStrokeColor(getLineEndingRenderGroup(document, renderIndex, id));
+}
+
+
+const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, const std::string& id, const std::string& strokeColor) {
     addColor(document, getLineEnding(document, id), strokeColor);
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, id)), strokeColor);
-
     return setStrokeColor(getLineEndingRenderGroup(document, id), strokeColor);
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& strokeColor) {
     addColor(document, getLineEnding(document, renderIndex, id), strokeColor);
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setStrokeColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), strokeColor);
-
     return setStrokeColor(getLineEndingRenderGroup(document, renderIndex, id), strokeColor);
 }
 
-bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && isSetStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, id))))
-        return isSetStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, id)));
+int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor);
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeColor);
+}
 
+int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor);
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeColor);
+}
+
+bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
     return isSetStrokeWidth(getLineEndingRenderGroup(document, id));
 }
 
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && isSetStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))))
-        return isSetStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return isSetStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const double getLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && getStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, id))) > 0.01)
-        return getStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, id)));
+bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+const double getLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
     return getStrokeWidth(getLineEndingRenderGroup(document, id));
 }
 
 const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && getStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))) > 0.01)
-        return getStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-int setLineEndingStrokeWidth(SBMLDocument* document, const std::string& id, double strokeWidth) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, id)), strokeWidth);
+const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+int setLineEndingStrokeWidth(SBMLDocument* document, const std::string& id, double strokeWidth) {
     return setStrokeWidth(getLineEndingRenderGroup(document, id), strokeWidth);
 }
 
 int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, double strokeWidth) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setStrokeWidth(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), strokeWidth);
-
     return setStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id), strokeWidth);
 }
 
-bool isSetLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && isSetStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, id))))
-        return isSetStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, id)));
+int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+    return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
+}
 
+int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+    return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
+}
+
+bool isSetLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id) {
     return isSetStrokeDashArray(getLineEndingRenderGroup(document, id));
 }
 
 bool isSetLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && isSetStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))))
-        return isSetStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return isSetStrokeDashArray(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
 const std::vector<unsigned int> getLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && !getStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, id))).empty())
-        return getStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, id)));
-
     return getStrokeDashArray(getLineEndingRenderGroup(document, id));
 }
 
 const std::vector<unsigned int> getLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && !getStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))).empty())
-        return getStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getStrokeDashArray(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
 int setLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id, const std::vector<unsigned int>& strokeDashArray) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, id)), strokeDashArray);
-
     return setStrokeDashArray(getLineEndingRenderGroup(document, id), strokeDashArray);
 }
 
 int setLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::vector<unsigned int>& strokeDashArray) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setStrokeDashArray(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), strokeDashArray);
-
     return setStrokeDashArray(getLineEndingRenderGroup(document, renderIndex, id), strokeDashArray);
 }
 
 unsigned int getNumLineEndingStrokeDashes(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return getNumStrokeDashes(getGeometricShape(getLineEndingRenderGroup(document, id)));
-
     return getNumStrokeDashes(getLineEndingRenderGroup(document, id));
 }
 
 unsigned int getNumLineEndingStrokeDashes(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return getNumStrokeDashes(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getNumStrokeDashes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-unsigned int getLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dashIndex) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return getStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, id)), dashIndex);
+unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumSpeciesReferenceLineEndingStrokeDashes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumStrokeDashes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+unsigned int getLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dashIndex) {
     return getStrokeDash(getLineEndingRenderGroup(document, id), dashIndex);
 }
 
 unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return getStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), dashIndex);
-
     return getStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex);
 }
 
-int setLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dash) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, id)), dash);
+unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getSpeciesReferenceLineEndingStrokeDash(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, dashIndex);
+}
 
+unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getStrokeDash(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex);
+}
+
+int setLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dash) {
     return setStrokeDash(getLineEndingRenderGroup(document, id), dash);
 }
 
 int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dash) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), dash);
-
     return setStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dash);
 }
 
-
 int setLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dashIndex, unsigned int dash) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, id)), dashIndex, dash);
-
     return setStrokeDash(getLineEndingRenderGroup(document, id), dashIndex, dash);
 }
 
 int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex, unsigned int dash) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setStrokeDash(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), dashIndex, dash);
-
     return setStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex, dash);
 }
 
-bool isSetLineEndingFillColor(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && isSetFillColor(getGeometricShape(getLineEndingRenderGroup(document, id))))
-        return isSetFillColor(getGeometricShape(getLineEndingRenderGroup(document, id)));
+int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+    return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
+}
 
+int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+    return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
+}
+
+bool isSetLineEndingFillColor(SBMLDocument* document, const std::string& id) {
     return isSetFillColor(getLineEndingRenderGroup(document, id));
 }
 
 bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && isSetFillColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))))
-        return isSetFillColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return isSetFillColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getLineEndingFillColor(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && !getFillColor(getGeometricShape(getLineEndingRenderGroup(document, id))).empty())
-        return getFillColor(getGeometricShape(getLineEndingRenderGroup(document, id)));
+bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+const std::string getLineEndingFillColor(SBMLDocument* document, const std::string& id) {
     return getFillColor(getLineEndingRenderGroup(document, id));
 }
 
 const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && !getFillColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))).empty())
-        return getFillColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getFillColor(getLineEndingRenderGroup(document, renderIndex, id));
+}
+
+const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fillColor) {
     addColor(document, getLineEnding(document, id), fillColor);
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setFillColor(getGeometricShape(getLineEndingRenderGroup(document, id)), fillColor);
-
     return setFillColor(getLineEndingRenderGroup(document, id), fillColor);
 }
 
 int setLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillColor) {
     addColor(document, getLineEnding(document, renderIndex, id), fillColor);
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setFillColor(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), fillColor);
-
     return setFillColor(getLineEndingRenderGroup(document, renderIndex, id), fillColor);
 }
 
-bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && isSetFillRule(getGeometricShape(getLineEndingRenderGroup(document, id))))
-        return isSetFillRule(getGeometricShape(getLineEndingRenderGroup(document, id)));
+int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor);
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillColor);
+}
 
+int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor);
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillColor);
+}
+
+bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
     return isSetFillRule(getLineEndingRenderGroup(document, id));
 }
 
 bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && isSetFillRule(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))))
-        return isSetFillRule(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return isSetFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getLineEndingFillRule(SBMLDocument* document, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1 && !getFillRule(getGeometricShape(getLineEndingRenderGroup(document, id))).empty())
-        return getFillRule(getGeometricShape(getLineEndingRenderGroup(document, id)));
+bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+const std::string getLineEndingFillRule(SBMLDocument* document, const std::string& id) {
     return getFillRule(getLineEndingRenderGroup(document, id));
 }
 
 const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1 && !getFillRule(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id))).empty())
-        return getFillRule(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)));
-
     return getFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-int setLineEndingFillRule(SBMLDocument* document, const std::string& id, const std::string& fillRule) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, id)) == 1)
-        return setFillRule(getGeometricShape(getLineEndingRenderGroup(document, id)), fillRule);
+const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
 
+const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
+int setLineEndingFillRule(SBMLDocument* document, const std::string& id, const std::string& fillRule) {
     return setFillRule(getLineEndingRenderGroup(document, id), fillRule);
 }
 
 int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillRule) {
-    if (getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id)) == 1)
-        return setFillRule(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id)), fillRule);
-
     return setFillRule(getLineEndingRenderGroup(document, renderIndex, id), fillRule);
+}
+
+int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+    return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
+}
+
+int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+    return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
 }
 
 unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, const std::string& id) {
@@ -1231,12 +1353,28 @@ unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned in
     return getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
+unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumSpeciesReferenceLineEndingGeometricShapes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumGeometricShapes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+}
+
 bool isLineEndingRectangle(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isRectangle(getGeometricShape(getLineEndingRenderGroup(document, id), geometricShapeIndex));
 }
 
 bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isRectangle(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
+}
+
+bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSpeciesReferenceLineEndingRectangle(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRectangle(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingEllipse(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1247,12 +1385,28 @@ bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const
     return isEllipse(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
+bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 bool isLineEndingPolygon(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isPolygon(getGeometricShape(getLineEndingRenderGroup(document, id), geometricShapeIndex));
 }
 
 bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isPolygon(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
+}
+
+bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingImage(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1263,12 +1417,28 @@ bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const s
     return isImage(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
+bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 bool isLineEndingRenderCurve(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isRenderCurve(getGeometricShape(getLineEndingRenderGroup(document, id), geometricShapeIndex));
 }
 
 bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isRenderCurve(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
+}
+
+bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingText(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1279,12 +1449,28 @@ bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const st
     return isText(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
+bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 bool isSetLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeX(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
 
 bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1295,14 +1481,32 @@ const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned
     return getGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector xVector = getLineEndingGeometricShapeX(document, id, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(xVector);
+    return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(xVector);
 }
 
 const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector xVector = getLineEndingGeometricShapeX(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(xVector);
+    return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
 }
 
 int setLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& x) {
@@ -1313,12 +1517,28 @@ int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderInde
     return setGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
+}
+
 int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, x);
 }
 
 int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+    return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+    return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
 bool isSetLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1329,6 +1549,14 @@ bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderI
     return isSetGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeY(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1337,15 +1565,35 @@ const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned
     return getGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+
 const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector yVector = getLineEndingGeometricShapeY(document, id, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(yVector);
+    return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(yVector);
 }
 
 const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector yVector = getLineEndingGeometricShapeY(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(yVector);
+    return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
 }
+
+const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+}
+
 
 int setLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getLineEndingRenderGroup(document, id), geometricShapeIndex, y);
@@ -1353,6 +1601,14 @@ int setLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, 
 
 int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
 int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& y) {
@@ -1363,12 +1619,28 @@ int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int re
     return setGeometricShapeYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+    return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+    return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
+}
+
 bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeWidth(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
 
 bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1379,14 +1651,32 @@ const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsi
     return getGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector widthVector = getLineEndingGeometricShapeWidth(document, id, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(widthVector);
+    return getAbsoluteValue(widthVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(widthVector);
 }
 
 const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector widthVector = getLineEndingGeometricShapeWidth(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(widthVector);
+    return getAbsoluteValue(widthVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(widthVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
 }
 
 int setLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& width) {
@@ -1397,12 +1687,28 @@ int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int render
     return setGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
+}
+
 int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, width);
 }
 
 int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+    return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+    return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
 bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1413,6 +1719,14 @@ bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int re
     return isSetGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeHeight(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1421,14 +1735,32 @@ const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, uns
     return getGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector heightVector = getLineEndingGeometricShapeHeight(document, id, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(heightVector);
+    return getAbsoluteValue(heightVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(heightVector);
 }
 
 const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector heightVector = getLineEndingGeometricShapeHeight(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(heightVector);
+    return getAbsoluteValue(heightVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(heightVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
 }
 
 int setLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& height) {
@@ -1439,12 +1771,28 @@ int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int rende
     return setGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
+}
+
 int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, height);
 }
 
 int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+    return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+    return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
 bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1455,12 +1803,28 @@ bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int ren
     return isSetGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeRatio(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 int setLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, double ratio) {
@@ -1471,12 +1835,28 @@ int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int render
     return setGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, ratio);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
+}
+
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     return isSetGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1487,14 +1867,32 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cornerCurvatureRadiusXVector = getLineEndingGeometricShapeCornerCurvatureRadiusX(document, id, geometricShapeIndex);
-    return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(cornerCurvatureRadiusXVector);
+    return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(cornerCurvatureRadiusXVector);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cornerCurvatureRadiusXVector = getLineEndingGeometricShapeCornerCurvatureRadiusX(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(cornerCurvatureRadiusXVector);
+    return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusXVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusX) {
@@ -1505,12 +1903,28 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
 int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1521,6 +1935,14 @@ bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document,
     return isSetGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1529,14 +1951,32 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cornerCurvatureRadiusYVector = getLineEndingGeometricShapeCornerCurvatureRadiusY(document, id, geometricShapeIndex);
-    return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(cornerCurvatureRadiusYVector);
+    return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(cornerCurvatureRadiusYVector);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cornerCurvatureRadiusYVector = getLineEndingGeometricShapeCornerCurvatureRadiusY(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(cornerCurvatureRadiusYVector);
+    return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusYVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusY) {
@@ -1547,12 +1987,28 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
 int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
 bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1563,6 +2019,14 @@ bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeCenterX(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1571,14 +2035,32 @@ const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, un
     return getGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cXVector = getLineEndingGeometricShapeCenterX(document, id, geometricShapeIndex);
-    return getAbsoluteValue(cXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(cXVector);
+    return getAbsoluteValue(cXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(cXVector);
 }
 
 const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
    RelAbsVector xVector = getLineEndingGeometricShapeCenterX(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(xVector);
+    return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
 }
 
 int setLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
@@ -1589,12 +2071,28 @@ int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
+}
+
 int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, centerX);
 }
 
 int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
 bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1605,6 +2103,14 @@ bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeCenterY(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1613,14 +2119,32 @@ const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, un
     return getGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector cYVector = getLineEndingGeometricShapeCenterY(document, id, geometricShapeIndex);
-    return getAbsoluteValue(cYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(cYVector);
+    return getAbsoluteValue(cYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(cYVector);
 }
 
 const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector yVector = getLineEndingGeometricShapeCenterY(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(yVector);
+    return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
 }
 
 int setLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
@@ -1631,12 +2155,28 @@ int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
+}
+
 int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, centerY);
 }
 
 int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
 bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1647,6 +2187,14 @@ bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeRadiusX(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1655,14 +2203,32 @@ const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, un
     return getGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector rXVector = getLineEndingGeometricShapeRadiusX(document, id, geometricShapeIndex);
-    return getAbsoluteValue(rXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(rXVector);
+    return getAbsoluteValue(rXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(rXVector);
 }
 
 const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector rXVector = getLineEndingGeometricShapeRadiusX(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(rXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(rXVector);
+    return getAbsoluteValue(rXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(rXVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
@@ -1673,12 +2239,28 @@ int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
 int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, radiusX);
 }
 
 int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
 bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1689,6 +2271,14 @@ bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeRadiusY(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1697,14 +2287,32 @@ const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, un
     return getGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector rYVector = getLineEndingGeometricShapeRadiusY(document, id, geometricShapeIndex);
-    return getAbsoluteValue(rYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(rYVector);
+    return getAbsoluteValue(rYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(rYVector);
 }
 
 const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex) {
     RelAbsVector rYVector = getLineEndingGeometricShapeRadiusY(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(rYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(rYVector);
+    return getAbsoluteValue(rYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(rYVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
@@ -1715,12 +2323,28 @@ int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
 int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, radiusY);
 }
 
 int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
 const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1731,12 +2355,28 @@ const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document
     return getGeometricShapeNumElements(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeNumElements(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     return isRenderCubicBezier(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex);
 }
 
 bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     return isRenderCubicBezier(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
+}
+
+bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isRenderCubicBezier(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1747,14 +2387,32 @@ const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, u
     return getGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeElementX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector elementXVector = getLineEndingGeometricShapeElementX(document, id, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(elementXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(elementXVector);
+    return getAbsoluteValue(elementXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(elementXVector);
 }
 
 const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector elementXVector = getLineEndingGeometricShapeElementX(document, renderIndex, id, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(elementXVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(elementXVector);
+    return getAbsoluteValue(elementXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(elementXVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
 }
 
 int setLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
@@ -1765,12 +2423,28 @@ int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
+}
+
 int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, x);
 }
 
 int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1781,14 +2455,32 @@ const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, u
     return getGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeElementY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector elementYVector = getLineEndingGeometricShapeElementY(document, id, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(elementYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(elementYVector);
+    return getAbsoluteValue(elementYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(elementYVector);
 }
 
 const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector elementYVector = getLineEndingGeometricShapeElementY(document, renderIndex, id, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(elementYVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(elementYVector);
+    return getAbsoluteValue(elementYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(elementYVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
 }
 
 int setLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
@@ -1799,12 +2491,28 @@ int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
+}
+
 int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, y);
 }
 
 int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1815,14 +2523,32 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document
     return getGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint1XVector = getLineEndingGeometricShapeBasePoint1X(document, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint1XVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(basePoint1XVector);
+    return getAbsoluteValue(basePoint1XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(basePoint1XVector);
 }
 
 const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint1XVector = getLineEndingGeometricShapeBasePoint1X(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint1XVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(basePoint1XVector);
+    return getAbsoluteValue(basePoint1XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint1XVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
 }
 
 int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
@@ -1833,12 +2559,28 @@ int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
+}
+
 int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
 int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1849,14 +2591,32 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document
     return getGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint1YVector = getLineEndingGeometricShapeBasePoint1Y(document, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint1YVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(basePoint1YVector);
+    return getAbsoluteValue(basePoint1YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(basePoint1YVector);
 }
 
 const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint1YVector = getLineEndingGeometricShapeBasePoint1Y(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint1YVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(basePoint1YVector);
+    return getAbsoluteValue(basePoint1YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint1YVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
 }
 
 int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
@@ -1867,12 +2627,28 @@ int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
+}
+
 int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
 int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1883,14 +2659,32 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document
     return getGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint2XVector = getLineEndingGeometricShapeBasePoint2X(document, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint2XVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, id)) * getRelativeValue(basePoint2XVector);
+    return getAbsoluteValue(basePoint2XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, id) * getRelativeValue(basePoint2XVector);
 }
 
 const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint2XVector = getLineEndingGeometricShapeBasePoint2X(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint2XVector) + 0.01 * getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(basePoint2XVector);
+    return getAbsoluteValue(basePoint2XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint2XVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
 }
 
 int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
@@ -1901,12 +2695,28 @@ int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
+}
+
 int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
 int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -1917,14 +2727,32 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document
     return getGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+}
+
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+}
+
 const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint2YVector = getLineEndingGeometricShapeBasePoint2Y(document, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint2YVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, id)) * getRelativeValue(basePoint2YVector);
+    return getAbsoluteValue(basePoint2YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, id) * getRelativeValue(basePoint2YVector);
 }
 
 const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     RelAbsVector basePoint2YVector = getLineEndingGeometricShapeBasePoint2Y(document, renderIndex, id, geometricShapeIndex);
-    return getAbsoluteValue(basePoint2YVector) + 0.01 * getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, id)) * getRelativeValue(basePoint2YVector);
+    return getAbsoluteValue(basePoint2YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint2YVector);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
+}
+
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
 }
 
 int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
@@ -1935,12 +2763,28 @@ int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
+}
+
 int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
 int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
 bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1951,6 +2795,14 @@ bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int rend
     return isSetGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
     return getGeometricShapeHref(getLineEndingRenderGroup(document, id), geometricShapeIndex);
 }
@@ -1959,12 +2811,28 @@ const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsign
     return getGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+}
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+}
+
 int setLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getLineEndingRenderGroup(document, id), geometricShapeIndex, href);
 }
 
 int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, href);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
+}
+
+int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
 }
 
 Style* getStyle(SBMLDocument* document, GraphicalObject* graphicalObject) {
@@ -2181,49 +3049,29 @@ RenderGroup* getRenderGroup(SBMLDocument* document, unsigned int renderIndex, co
 }
 
 bool isSetStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeColor(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeColor(getGeometricShape(style)))
-            return isSetStrokeColor(getGeometricShape(style));
-
-        return isSetStrokeColor(style);
-    }
+    if (canHaveStrokeColor(graphicalObject))
+        return isSetStrokeColor(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetStrokeColor(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeColor(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeColor(getGeometricShape(style)))
-            return isSetStrokeColor(getGeometricShape(style));
-
-        return isSetStrokeColor(style);
-    }
+    if (canHaveStrokeColor(getGraphicalObject(document, attribute)))
+        return isSetStrokeColor(getStyle(document, attribute));
 
     return false;
 }
 
 const std::string getStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeColor(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && !getStrokeColor(getGeometricShape(style)).empty())
-            return getStrokeColor(getGeometricShape(style));
-
-        return getStrokeColor(style);
-    }
+    if (canHaveStrokeColor(graphicalObject))
+        return getStrokeColor(getStyle(document, graphicalObject));
 
     return "";
 }
 
 const std::string getStrokeColor(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeColor(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && !getStrokeColor(getGeometricShape(style)).empty())
-            return getStrokeColor(getGeometricShape(style));
-
-        return getStrokeColor(style);
-    }
+    if (canHaveStrokeColor(getGraphicalObject(document, attribute)))
+        return getStrokeColor(getStyle(document, attribute));
 
     return "";
 }
@@ -2324,49 +3172,29 @@ int setStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::
 }
 
 bool isSetStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeWidth(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeWidth(getGeometricShape(style)))
-            return isSetStrokeWidth(getGeometricShape(style));
-
-        return isSetStrokeWidth(style);
-    }
+    if (canHaveStrokeWidth(graphicalObject))
+        return isSetStrokeWidth(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetStrokeWidth(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeWidth(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeWidth(getGeometricShape(style)))
-            return isSetStrokeWidth(getGeometricShape(style));
-
-        return isSetStrokeWidth(style);
-    }
+    if (canHaveStrokeWidth(getGraphicalObject(document, attribute)))
+        return isSetStrokeWidth(getStyle(document, attribute));
 
     return false;
 }
 
 const double getStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeWidth(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && getStrokeWidth(getGeometricShape(style)) > 0.01)
-            return getStrokeWidth(getGeometricShape(style));
-
-        return getStrokeWidth(style);
-    }
+    if (canHaveStrokeWidth(graphicalObject))
+        return getStrokeWidth(getStyle(document, graphicalObject));
 
     return NAN;
 }
 
 const double getStrokeWidth(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeWidth(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && getStrokeWidth(getGeometricShape(style)) > 0.01)
-            return getStrokeWidth(getGeometricShape(style));
-
-        return getStrokeWidth(style);
-    }
+    if (canHaveStrokeWidth(getGraphicalObject(document, attribute)))
+        return getStrokeWidth(getStyle(document, attribute));
 
     return NAN;
 }
@@ -2467,95 +3295,57 @@ int setStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const doubl
 }
 
 bool isSetStrokeDashArray(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeDashArray(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeDashArray(getGeometricShape(style)))
-            return isSetStrokeDashArray(getGeometricShape(style));
-
-        return isSetStrokeDashArray(style);
-    }
+    if (canHaveStrokeDashArray(graphicalObject))
+        return isSetStrokeDashArray(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetStrokeDashArray(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isSetStrokeDashArray(getGeometricShape(style)))
-            return isSetStrokeDashArray(getGeometricShape(style));
-
-        return isSetStrokeDashArray(style);
-    }
+    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute)))
+        return isSetStrokeDashArray(getStyle(document, attribute));
 
     return false;
 }
 
 const std::vector<unsigned int> getStrokeDashArray(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeDashArray(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && getStrokeDashArray(getGeometricShape(style)).size())
-            return getStrokeDashArray(getGeometricShape(style));
-
-        return getStrokeDashArray(style);
-    }
+    if (canHaveStrokeDashArray(graphicalObject))
+        return getStrokeDashArray(getStyle(document, graphicalObject));
 
     return std::vector<unsigned int>();
 }
 
 const std::vector<unsigned int> getStrokeDashArray(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && getStrokeDashArray(getGeometricShape(style)).size())
-            return getStrokeDashArray(getGeometricShape(style));
-
-        return getStrokeDashArray(style);
-    }
+    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute)))
+        return getStrokeDashArray(getStyle(document, attribute));
 
     return std::vector<unsigned int>();
 }
 
 int setStrokeDashArray(SBMLDocument* document, GraphicalObject* graphicalObject, const std::vector<unsigned int>& strokeDashArray) {
-    if (canHaveStrokeDashArray(graphicalObject)) {
-        Style* style = getLocalStyle(document, graphicalObject);
-        if (!style)
-            style = createLocalStyle(document, graphicalObject);
-        return setStrokeDashArray(style, strokeDashArray);
-    }
+    if (canHaveStrokeDashArray(graphicalObject))
+        return setStrokeDashArray(getStyle(document, graphicalObject), strokeDashArray);
 
     return -1;
 }
 
 int setStrokeDashArray(SBMLDocument* document, const std::string& attribute, const std::vector<unsigned int>& strokeDashArray) {
-    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute))) {
-        Style* style = getLocalStyle(document, attribute);
-        if (!style)
-            style = createLocalStyle(document, attribute);
-        return setStrokeDashArray(style, strokeDashArray);
-    }
+    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute)))
+        return setStrokeDashArray(getStyle(document, attribute), strokeDashArray);
 
     return -1;
 }
 
 unsigned int getNumStrokeDashes(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStrokeDashArray(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && getNumStrokeDashes(getGeometricShape(style)))
-            return getNumStrokeDashes(getGeometricShape(style));
-
-        return getNumStrokeDashes(style);
-    }
+    if (canHaveStrokeDashArray(graphicalObject))
+        return getNumStrokeDashes(getStyle(document, graphicalObject));
 
     return 0;
 }
 
 unsigned int getNumStrokeDashes(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && getNumStrokeDashes(getGeometricShape(style)))
-            return getNumStrokeDashes(getGeometricShape(style));
-
-        return getNumStrokeDashes(style);
-    }
+    if (canHaveStrokeDashArray(getGraphicalObject(document, attribute)))
+        return getNumStrokeDashes(getStyle(document, attribute));
 
     return 0;
 }
@@ -2627,8 +3417,6 @@ bool isSetFontColor(SBMLDocument* document, GraphicalObject* graphicalObject, un
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontColor(getGeometricShape(style));
 
         return isSetFontColor(style);
     }
@@ -2642,8 +3430,6 @@ bool isSetFontColor(SBMLDocument* document, const std::string& attribute, unsign
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontColor(getGeometricShape(style));
 
         return isSetFontColor(style);
     }
@@ -2657,8 +3443,6 @@ const std::string getFontColor(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontColor(getGeometricShape(style));
 
         return getFontColor(style);
     }
@@ -2672,8 +3456,6 @@ const std::string getFontColor(SBMLDocument* document, const std::string& attrib
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontColor(getGeometricShape(style));
 
         return getFontColor(style);
     }
@@ -2692,9 +3474,6 @@ int setFontColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsig
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
         addColor(document, style, fontColor);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontColor(getGeometricShape(style), fontColor);
-
         return setFontColor(style, fontColor);
     }
 
@@ -2712,9 +3491,6 @@ int setFontColor(SBMLDocument* document, const std::string& attribute, unsigned 
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
         addColor(document, style, fontColor);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontColor(getGeometricShape(style), fontColor);
-
         return setFontColor(style, fontColor);
     }
 
@@ -2774,8 +3550,6 @@ bool isSetFontFamily(SBMLDocument* document, GraphicalObject* graphicalObject, u
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontFamily(getGeometricShape(style));
 
         return isSetFontFamily(style);
     }
@@ -2789,8 +3563,6 @@ bool isSetFontFamily(SBMLDocument* document, const std::string& attribute, unsig
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontFamily(getGeometricShape(style));
 
         return isSetFontFamily(style);
     }
@@ -2804,8 +3576,6 @@ const std::string getFontFamily(SBMLDocument* document, GraphicalObject* graphic
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontFamily(getGeometricShape(style));
 
         return getFontFamily(style);
     }
@@ -2819,8 +3589,6 @@ const std::string getFontFamily(SBMLDocument* document, const std::string& attri
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontFamily(getGeometricShape(style));
 
         return getFontFamily(style);
     }
@@ -2838,8 +3606,6 @@ int setFontFamily(SBMLDocument* document, GraphicalObject* graphicalObject, unsi
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontFamily(getGeometricShape(style), fontFamily);
 
         return setFontFamily(style, fontFamily);
     }
@@ -2857,8 +3623,6 @@ int setFontFamily(SBMLDocument* document, const std::string& attribute, unsigned
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontFamily(getGeometricShape(style), fontFamily);
 
         return setFontFamily(style, fontFamily);
     }
@@ -2919,8 +3683,6 @@ bool isSetFontSize(SBMLDocument* document, GraphicalObject* graphicalObject, uns
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontSize(getGeometricShape(style));
 
         return isSetFontSize(style);
     }
@@ -2934,8 +3696,6 @@ bool isSetFontSize(SBMLDocument* document, const std::string& attribute, unsigne
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontSize(getGeometricShape(style));
 
         return isSetFontSize(style);
     }
@@ -2949,8 +3709,6 @@ const RelAbsVector getFontSize(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontSize(getGeometricShape(style));
 
         return getFontSize(style);
     }
@@ -2964,8 +3722,6 @@ const RelAbsVector getFontSize(SBMLDocument* document, const std::string& attrib
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontSize(getGeometricShape(style));
 
         return getFontSize(style);
     }
@@ -2993,8 +3749,6 @@ int setFontSize(SBMLDocument* document, GraphicalObject* graphicalObject, unsign
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontSize(getGeometricShape(style), fontSize);
 
         return setFontSize(style, fontSize);
     }
@@ -3012,8 +3766,6 @@ int setFontSize(SBMLDocument* document, const std::string& attribute, unsigned i
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontSize(getGeometricShape(style), fontSize);
 
         return setFontSize(style, fontSize);
     }
@@ -3031,8 +3783,6 @@ int setFontSizeAsDouble(SBMLDocument* document, GraphicalObject* graphicalObject
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontSizeAsDouble(getGeometricShape(style), fontSize);
 
         return setFontSizeAsDouble(style, fontSize);
     }
@@ -3050,8 +3800,6 @@ int setFontSizeAsDouble(SBMLDocument* document, const std::string& attribute, un
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontSizeAsDouble(getGeometricShape(style), fontSize);
 
         return setFontSizeAsDouble(style, fontSize);
     }
@@ -3159,8 +3907,6 @@ bool isSetFontWeight(SBMLDocument* document, GraphicalObject* graphicalObject, u
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontWeight(getGeometricShape(style));
 
         return isSetFontWeight(style);
     }
@@ -3174,8 +3920,6 @@ bool isSetFontWeight(SBMLDocument* document, const std::string& attribute, unsig
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontWeight(getGeometricShape(style));
 
         return isSetFontWeight(style);
     }
@@ -3189,8 +3933,6 @@ const std::string getFontWeight(SBMLDocument* document, GraphicalObject* graphic
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontWeight(getGeometricShape(style));
 
         return getFontWeight(style);
     }
@@ -3204,8 +3946,6 @@ const std::string getFontWeight(SBMLDocument* document, const std::string& attri
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontWeight(getGeometricShape(style));
 
         return getFontWeight(style);
     }
@@ -3223,8 +3963,6 @@ int setFontWeight(SBMLDocument* document, GraphicalObject* graphicalObject, unsi
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontWeight(getGeometricShape(style), fontWeight);
 
         return setFontWeight(style, fontWeight);
     }
@@ -3242,8 +3980,6 @@ int setFontWeight(SBMLDocument* document, const std::string& attribute, unsigned
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontWeight(getGeometricShape(style), fontWeight);
 
         return setFontWeight(style, fontWeight);
     }
@@ -3304,8 +4040,6 @@ bool isSetFontStyle(SBMLDocument* document, GraphicalObject* graphicalObject, un
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontStyle(getGeometricShape(style));
 
         return isSetFontStyle(style);
     }
@@ -3319,8 +4053,6 @@ bool isSetFontStyle(SBMLDocument* document, const std::string& attribute, unsign
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetFontStyle(getGeometricShape(style));
 
         return isSetFontStyle(style);
     }
@@ -3334,8 +4066,6 @@ const std::string getFontStyle(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontStyle(getGeometricShape(style));
 
         return getFontStyle(style);
     }
@@ -3349,8 +4079,6 @@ const std::string getFontStyle(SBMLDocument* document, const std::string& attrib
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getFontStyle(getGeometricShape(style));
 
         return getFontStyle(style);
     }
@@ -3368,8 +4096,6 @@ int setFontStyle(SBMLDocument* document, GraphicalObject* graphicalObject, unsig
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontStyle(getGeometricShape(style), fontStyle);
 
         return setFontStyle(style, fontStyle);
     }
@@ -3387,8 +4113,6 @@ int setFontStyle(SBMLDocument* document, const std::string& attribute, unsigned 
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setFontStyle(getGeometricShape(style), fontStyle);
 
         return setFontStyle(style, fontStyle);
     }
@@ -3449,8 +4173,6 @@ bool isSetTextAnchor(SBMLDocument* document, GraphicalObject* graphicalObject, u
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetTextAnchor(getGeometricShape(style));
 
         return isSetTextAnchor(style);
     }
@@ -3464,8 +4186,6 @@ bool isSetTextAnchor(SBMLDocument* document, const std::string& attribute, unsig
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetTextAnchor(getGeometricShape(style));
 
         return isSetTextAnchor(style);
     }
@@ -3479,8 +4199,6 @@ const std::string getTextAnchor(SBMLDocument* document, GraphicalObject* graphic
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getTextAnchor(getGeometricShape(style));
 
         return getTextAnchor(style);
     }
@@ -3494,8 +4212,6 @@ const std::string getTextAnchor(SBMLDocument* document, const std::string& attri
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getTextAnchor(getGeometricShape(style));
 
         return getTextAnchor(style);
     }
@@ -3513,8 +4229,6 @@ int setTextAnchor(SBMLDocument* document, GraphicalObject* graphicalObject, unsi
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setTextAnchor(getGeometricShape(style), textAnchor);
 
         return setTextAnchor(style, textAnchor);
     }
@@ -3532,8 +4246,6 @@ int setTextAnchor(SBMLDocument* document, const std::string& attribute, unsigned
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setTextAnchor(getGeometricShape(style), textAnchor);
 
         return setTextAnchor(style, textAnchor);
     }
@@ -3594,8 +4306,6 @@ bool isSetVTextAnchor(SBMLDocument* document, GraphicalObject* graphicalObject, 
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetVTextAnchor(getGeometricShape(style));
 
         return isSetVTextAnchor(style);
     }
@@ -3609,8 +4319,6 @@ bool isSetVTextAnchor(SBMLDocument* document, const std::string& attribute, unsi
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return isSetVTextAnchor(getGeometricShape(style));
 
         return isSetVTextAnchor(style);
     }
@@ -3624,8 +4332,6 @@ const std::string getVTextAnchor(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getVTextAnchor(getGeometricShape(style));
 
         return getVTextAnchor(style);
     }
@@ -3639,8 +4345,6 @@ const std::string getVTextAnchor(SBMLDocument* document, const std::string& attr
         Style* style = getStyle(document, textGlyph);
         if (!style)
             style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return getVTextAnchor(getGeometricShape(style));
 
         return getVTextAnchor(style);
     }
@@ -3658,8 +4362,6 @@ int setVTextAnchor(SBMLDocument* document, GraphicalObject* graphicalObject, uns
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setVTextAnchor(getGeometricShape(style), vtextAnchor);
 
         return setVTextAnchor(style, vtextAnchor);
     }
@@ -3677,8 +4379,6 @@ int setVTextAnchor(SBMLDocument* document, const std::string& attribute, unsigne
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        if (getNumGeometricShapes(style) == 1 && isText(getGeometricShape(style)))
-            return setVTextAnchor(getGeometricShape(style), vtextAnchor);
 
         return setVTextAnchor(style, vtextAnchor);
     }
@@ -3734,49 +4434,29 @@ int setVTextAnchor(SBMLDocument* document, unsigned int layoutIndex, const std::
 }
 
 bool isSetFillColor(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveFillColor(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isSetFillColor(getGeometricShape(style)))
-            return isSetFillColor(getGeometricShape(style));
-
-        return isSetFillColor(style);
-    }
+    if (canHaveFillColor(graphicalObject))
+        return isSetFillColor(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetFillColor(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveFillColor(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isSetFillColor(getGeometricShape(style)))
-            return isSetFillColor(getGeometricShape(style));
-
-        return isSetFillColor(style);
-    }
+    if (canHaveFillColor(getGraphicalObject(document, attribute)))
+        return isSetFillColor(getStyle(document, attribute));
 
     return false;
 }
 
 const std::string getFillColor(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveFillColor(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && !getFillColor(getGeometricShape(style)).empty())
-            return getFillColor(getGeometricShape(style));
-
-        return getFillColor(style);
-    }
+    if (canHaveFillColor(graphicalObject))
+        return getFillColor(getStyle(document, graphicalObject));
 
     return "";
 }
 
 const std::string getFillColor(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveFillColor(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && !getFillColor(getGeometricShape(style)).empty())
-            return getFillColor(getGeometricShape(style));
-
-        return getFillColor(style);
-    }
+    if (canHaveFillColor(getGraphicalObject(document, attribute)))
+        return getFillColor(getStyle(document, attribute));
 
     return "";
 }
@@ -3787,9 +4467,6 @@ int setFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const
         if (!style)
             style = createLocalStyle(document, graphicalObject);
         addColor(document, style, fillColor);
-        if (getNumGeometricShapes(style) == 1 && isSetFillColor(getGeometricShape(style)))
-            return setFillColor(getGeometricShape(style), fillColor);
-
         return setFillColor(style, fillColor);
     }
 
@@ -3802,9 +4479,6 @@ int setFillColor(SBMLDocument* document, const std::string& attribute, const std
         if (!style)
             style = createLocalStyle(document, attribute);
         addColor(document, style, fillColor);
-        if (getNumGeometricShapes(style) == 1 && isSetFillColor(getGeometricShape(style)))
-            return setFillColor(getGeometricShape(style), fillColor);
-
         return setFillColor(style, fillColor);
     }
 
@@ -3876,49 +4550,29 @@ int setFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::st
 }
 
 bool isSetFillRule(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveFillRule(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return isSetFillRule(getGeometricShape(style));
-
-        return isSetFillRule(style);
-    }
+    if (canHaveFillRule(graphicalObject))
+        return isSetFillRule(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetFillRule(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveFillRule(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return isSetFillRule(getGeometricShape(style));
-
-        return isSetFillRule(style);
-    }
+    if (canHaveFillRule(getGraphicalObject(document, attribute)))
+        return isSetFillRule(getStyle(document, attribute));
 
     return false;
 }
 
 const std::string getFillRule(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveFillRule(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return getFillRule(getGeometricShape(style));
-
-        return getFillRule(style);
-    }
+    if (canHaveFillRule(graphicalObject))
+        return getFillRule(getStyle(document, graphicalObject));
 
     return "";
 }
 
 const std::string getFillRule(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveFillRule(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return getFillRule(getGeometricShape(style));
-
-        return getFillRule(style);
-    }
+    if (canHaveFillRule(getGraphicalObject(document, attribute)))
+        return getFillRule(getStyle(document, attribute));
 
     return "";
 }
@@ -3928,9 +4582,6 @@ int setFillRule(SBMLDocument* document, GraphicalObject* graphicalObject, const 
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return setFillRule(getGeometricShape(style), fillRule);
-
         return setFillRule(style, fillRule);
     }
 
@@ -3942,9 +4593,6 @@ int setFillRule(SBMLDocument* document, const std::string& attribute, const std:
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isPolygon(getGeometricShape(style)))
-            return setFillRule(getGeometricShape(style), fillRule);
-
         return setFillRule(style, fillRule);
     }
 
@@ -4016,49 +4664,29 @@ int setFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::str
 }
 
 bool isSetStartHead(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStartHead(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return isSetStartHead(getGeometricShape(style));
-
-        return isSetStartHead(style);
-    }
+    if (canHaveStartHead(graphicalObject))
+        return isSetStartHead(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetStartHead(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStartHead(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return isSetStartHead(getGeometricShape(style));
-
-        return isSetStartHead(style);
-    }
+    if (canHaveStartHead(getGraphicalObject(document, attribute)))
+        return isSetStartHead(getStyle(document, attribute));
 
     return false;
 }
 
 const std::string getStartHead(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveStartHead(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return getStartHead(getGeometricShape(style));
-
-        return getStartHead(style);
-    }
+    if (canHaveStartHead(graphicalObject))
+        return getStartHead(getStyle(document, graphicalObject));
 
     return "";
 }
 
 const std::string getStartHead(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveStartHead(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return getStartHead(getGeometricShape(style));
-
-        return getStartHead(style);
-    }
+    if (canHaveStartHead(getGraphicalObject(document, attribute)))
+        return getStartHead(getStyle(document, attribute));
 
     return "";
 }
@@ -4068,9 +4696,6 @@ int setStartHead(SBMLDocument* document, GraphicalObject* graphicalObject, const
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return setStartHead(getGeometricShape(style), startHead);
-
         return setStartHead(style, startHead);
     }
 
@@ -4082,9 +4707,6 @@ int setStartHead(SBMLDocument* document, const std::string& attribute, const std
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return setStartHead(getGeometricShape(style), startHead);
-
         return setStartHead(style, startHead);
     }
 
@@ -4092,49 +4714,29 @@ int setStartHead(SBMLDocument* document, const std::string& attribute, const std
 }
 
 bool isSetEndHead(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveEndHead(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return isSetEndHead(getGeometricShape(style));
-
-        return isSetEndHead(style);
-    }
+    if (canHaveEndHead(graphicalObject))
+        return isSetEndHead(getStyle(document, graphicalObject));
 
     return false;
 }
 
 bool isSetEndHead(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveEndHead(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return isSetEndHead(getGeometricShape(style));
-
-        return isSetEndHead(style);
-    }
+    if (canHaveEndHead(getGraphicalObject(document, attribute)))
+        return isSetEndHead(getStyle(document, attribute));
 
     return false;
 }
 
 const std::string getEndHead(SBMLDocument* document, GraphicalObject* graphicalObject) {
-    if (canHaveEndHead(graphicalObject)) {
-        Style* style = getStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return getEndHead(getGeometricShape(style));
-
-        return getEndHead(style);
-    }
+    if (canHaveEndHead(graphicalObject))
+        return getEndHead(getStyle(document, graphicalObject));
 
     return "";
 }
 
 const std::string getEndHead(SBMLDocument* document, const std::string& attribute) {
-    if (canHaveEndHead(getGraphicalObject(document, attribute))) {
-        Style* style = getStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return getEndHead(getGeometricShape(style));
-
-        return getEndHead(style);
-    }
+    if (canHaveEndHead(getGraphicalObject(document, attribute)))
+        return getEndHead(getStyle(document, attribute));
 
     return "";
 }
@@ -4144,9 +4746,6 @@ int setEndHead(SBMLDocument* document, GraphicalObject* graphicalObject, const s
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return setEndHead(getGeometricShape(style), endHead);
-
         return setEndHead(style, endHead);
     }
 
@@ -4158,9 +4757,6 @@ int setEndHead(SBMLDocument* document, const std::string& attribute, const std::
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        if (getNumGeometricShapes(style) == 1 && isRenderCurve(getGeometricShape(style)))
-            return setEndHead(getGeometricShape(style), endHead);
-
         return setEndHead(style, endHead);
     }
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -4448,6 +4448,222 @@ bool isText(SBMLDocument* document, const std::string& attribute, unsigned int g
     return false;
 }
 
+bool isSetGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return isSetGeometricShapeStrokeColor(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return false;
+}
+
+bool isSetGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return isSetGeometricShapeStrokeColor(getStyle(document, attribute), geometricShapeIndex);
+
+    return false;
+}
+
+const std::string getGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return getGeometricShapeStrokeColor(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return "";
+}
+
+const std::string getGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return getGeometricShapeStrokeColor(getStyle(document, attribute), geometricShapeIndex);
+
+    return "";
+}
+
+int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& strokeColor) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeStrokeColor(style, 0, strokeColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeStrokeColor(style, geometricShapeIndex, strokeColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, const std::string& strokeColor) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeStrokeColor(style, 0, strokeColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& strokeColor) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeStrokeColor(style, geometricShapeIndex, strokeColor);
+    }
+
+    return -1;
+}
+
+bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return isSetGeometricShapeStrokeWidth(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return false;
+}
+
+bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return isSetGeometricShapeStrokeWidth(getStyle(document, attribute), geometricShapeIndex);
+
+    return false;
+}
+
+const double getGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return getGeometricShapeStrokeWidth(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return NAN;
+}
+
+const double getGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return getGeometricShapeStrokeWidth(getStyle(document, attribute), geometricShapeIndex);
+
+    return NAN;
+}
+
+int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, const double& strokeWidth) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeStrokeWidth(style, 0, strokeWidth);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeStrokeWidth(style, geometricShapeIndex, strokeWidth);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, const double& strokeWidth) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeStrokeWidth(style, 0, strokeWidth);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeStrokeWidth(style, geometricShapeIndex, strokeWidth);
+    }
+
+    return -1;
+}
+
+bool isSetGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return isSetGeometricShapeFillColor(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return false;
+}
+
+bool isSetGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return isSetGeometricShapeFillColor(getStyle(document, attribute), geometricShapeIndex);
+
+    return false;
+}
+
+const std::string getGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(graphicalObject))
+        return getGeometricShapeFillColor(getStyle(document, graphicalObject), geometricShapeIndex);
+
+    return "";
+}
+
+const std::string getGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute)))
+        return getGeometricShapeFillColor(getStyle(document, attribute), geometricShapeIndex);
+
+    return "";
+}
+
+int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& fillColor) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeFillColor(style, 0, fillColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeFillColor(style, geometricShapeIndex, fillColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeFillColor(style, 0, fillColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeFillColor(style, geometricShapeIndex, fillColor);
+    }
+
+    return -1;
+}
+
 bool isSetGeometricShapeX(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {
     if (canHaveGeometricShape(graphicalObject))
         return isSetGeometricShapeX(getStyle(document, graphicalObject), geometricShapeIndex);

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -5280,7 +5280,6 @@ int setFillColor(SBMLDocument* document, const std::string& attribute, const std
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        std::cout << "2) setting fill color to " << fillColor << std::endl;
         setReactionLineEndingFillColor(document, attribute, 0, fillColor);
         return setFillColor(style, addColor(document, style, fillColor));
     }

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -955,17 +955,21 @@ int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned i
 }
 
 int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxX(document, reactionId, reactionGlyphIndex, i, x);
+        if (!setSpeciesReferenceLineEndingBoundingBoxX(document, reactionId, reactionGlyphIndex, i, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, i, x);
+        if (!setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, i, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const double getLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid) {
@@ -1001,17 +1005,21 @@ int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned i
 }
 
 int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxY(document, reactionId, reactionGlyphIndex, i, y);
+        if (!setSpeciesReferenceLineEndingBoundingBoxY(document, reactionId, reactionGlyphIndex, i, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, i, y);
+        if (!setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, i, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const double getLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid) {
@@ -1049,17 +1057,21 @@ int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsign
 }
 
 int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, i, width);
+        if (!setSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, i, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, width);
+        if (!setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const double getLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid) {
@@ -1097,17 +1109,21 @@ int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsig
 }
 
 int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, i, height);
+        if (!setSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, i, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, height);
+        if (!setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 RenderGroup* getLineEndingRenderGroup(SBMLDocument* document, const std::string& sid) {
@@ -1168,17 +1184,21 @@ int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned in
 }
 
 int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeColor(document, reactionId, reactionGlyphIndex, i, strokeColor);
+        if (!setSpeciesReferenceLineEndingStrokeColor(document, reactionId, reactionGlyphIndex, i, strokeColor))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeColor);
+        if (!setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeColor))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1230,17 +1250,21 @@ int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned in
 }
 
 int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeWidth(document, reactionId, reactionGlyphIndex, i, strokeWidth);
+        if (!setSpeciesReferenceLineEndingStrokeWidth(document, reactionId, reactionGlyphIndex, i, strokeWidth))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeWidth);
+        if (!setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeWidth))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id) {
@@ -1324,17 +1348,21 @@ int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int
 }
 
 int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeDash(document, reactionId, reactionGlyphIndex, i, dashIndex, dash);
+        if (!setSpeciesReferenceLineEndingStrokeDash(document, reactionId, reactionGlyphIndex, i, dashIndex, dash))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, i, dashIndex, dash);
+        if (!setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, i, dashIndex, dash))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingFillColor(SBMLDocument* document, const std::string& id) {
@@ -1402,31 +1430,39 @@ int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, uns
 }
 
 int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillColor(document, reactionId, reactionGlyphIndex, i, fillColor);
+        if (!setSpeciesReferenceLineEndingFillColor(document, reactionId, reactionGlyphIndex, i, fillColor))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillColor);
+        if (!setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillColor))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillColorAsGradient(document, reactionId, reactionGlyphIndex, i, gradientType, stopsVector);
+        if (!setSpeciesReferenceLineEndingFillColorAsGradient(document, reactionId, reactionGlyphIndex, i, gradientType, stopsVector))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, i, gradientType, stopsVector);
+        if (!setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, i, gradientType, stopsVector))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -1478,17 +1514,21 @@ int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int l
 }
 
 int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillRule(document, reactionId, reactionGlyphIndex, i, fillRule);
+        if (!setSpeciesReferenceLineEndingFillRule(document, reactionId, reactionGlyphIndex, i, fillRule))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillRule);
+        if (!setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillRule))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, const std::string& id) {
@@ -1672,17 +1712,21 @@ int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigne
 }
 
 int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& x) {
@@ -1702,17 +1746,21 @@ int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document,
 }
 
 int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1786,17 +1834,21 @@ int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigne
 }
 
 int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& y) {
@@ -1816,17 +1868,21 @@ int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document,
 }
 
 int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1898,17 +1954,21 @@ int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, uns
 }
 
 int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+        if (!setSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+        if (!setSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& width) {
@@ -1928,17 +1988,21 @@ int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* docum
 }
 
 int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+        if (!setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+        if (!setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2010,17 +2074,21 @@ int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, un
 }
 
 int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& height) {
@@ -2040,17 +2108,21 @@ int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* docu
 }
 
 int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2102,17 +2174,21 @@ int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, uns
 }
 
 int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRatio(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRatio(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2184,17 +2260,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocume
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusX) {
@@ -2214,17 +2294,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SB
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2296,17 +2380,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocume
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusY) {
@@ -2326,17 +2414,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SB
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2408,17 +2500,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, u
 }
 
 int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerX) {
@@ -2438,17 +2534,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* doc
 }
 
 int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2520,17 +2620,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, u
 }
 
 int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerY) {
@@ -2550,17 +2654,21 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* doc
 }
 
 int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2632,17 +2740,21 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, u
 }
 
 int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX) {
@@ -2662,17 +2774,21 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* doc
 }
 
 int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2744,17 +2860,21 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, u
 }
 
 int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY) {
@@ -2774,17 +2894,21 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* doc
 }
 
 int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+        if (!setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2872,17 +2996,21 @@ int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, 
 }
 
 int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
@@ -2902,17 +3030,21 @@ int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* do
 }
 
 int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2968,17 +3100,21 @@ int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, 
 }
 
 int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
@@ -2998,17 +3134,21 @@ int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* do
 }
 
 int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -3064,17 +3204,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* documen
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
@@ -3094,17 +3238,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument*
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -3160,17 +3308,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* documen
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
@@ -3190,17 +3342,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument*
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -3256,17 +3412,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* documen
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
@@ -3286,17 +3446,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument*
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -3352,17 +3516,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* documen
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
@@ -3382,17 +3550,21 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument*
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+        if (!setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -3444,17 +3616,21 @@ int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsi
 }
 
 int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHref(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHref(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    int isSetSuccessfully = -1;
     for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
-        setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href);
+        if (!setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href))
+            isSetSuccessfully = 0;
 
-    return 0;
+    return isSetSuccessfully;
 }
 
 Style* getStyle(SBMLDocument* document, GraphicalObject* graphicalObject) {
@@ -3703,6 +3879,7 @@ int setStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, con
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingStrokeColor(document, getReactionId(graphicalObject), 0, stroke);
         return setStrokeColor(style, addColor(document, style, stroke));
     }
 
@@ -3714,6 +3891,7 @@ int setStrokeColor(SBMLDocument* document, const std::string& attribute, const s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingStrokeColor(document, attribute, 0, stroke);
         return setStrokeColor(style, addColor(document, style, stroke));
     }
 
@@ -3824,6 +4002,7 @@ int setStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, con
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingStrokeWidth(document, getReactionId(graphicalObject), 0, strokeWidth);
         return setStrokeWidth(style, strokeWidth);
     }
 
@@ -3835,6 +4014,7 @@ int setStrokeWidth(SBMLDocument* document, const std::string& attribute, const d
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingStrokeWidth(document, attribute, 0, strokeWidth);
         return setStrokeWidth(style, strokeWidth);
     }
 
@@ -3992,6 +4172,7 @@ unsigned int setStrokeDash(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingStrokeDash(document, getReactionId(graphicalObject), 0, 0, dash);
         return setStrokeDash(style, dash);
     }
 
@@ -4003,6 +4184,7 @@ unsigned int setStrokeDash(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingStrokeDash(document, getReactionId(graphicalObject), 0, 0, dash);
         return setStrokeDash(style, dashIndex, dash);
     }
 
@@ -4014,6 +4196,7 @@ unsigned int setStrokeDash(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingStrokeDash(document, attribute, 0, 0,dash);
         return setStrokeDash(style, dash);
     }
 
@@ -4025,6 +4208,7 @@ unsigned int setStrokeDash(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingStrokeDash(document, attribute, 0, 0, dash);
         return setStrokeDash(style, dashIndex, dash);
     }
 
@@ -5084,6 +5268,7 @@ int setFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingFillColor(document, getReactionId(graphicalObject), 0, fillColor);
         return setFillColor(style, addColor(document, style, fillColor));
     }
 
@@ -5095,6 +5280,8 @@ int setFillColor(SBMLDocument* document, const std::string& attribute, const std
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        std::cout << "2) setting fill color to " << fillColor << std::endl;
+        setReactionLineEndingFillColor(document, attribute, 0, fillColor);
         return setFillColor(style, addColor(document, style, fillColor));
     }
 
@@ -5106,6 +5293,7 @@ int setFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingFillColorAsGradient(document, getReactionId(graphicalObject), 0, gradientType, stopsVector);
         return setFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
     }
 
@@ -5117,6 +5305,7 @@ int setFillColorAsGradient(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingFillColorAsGradient(document, attribute, 0, gradientType, stopsVector);
         return setFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
     }
 
@@ -5272,6 +5461,7 @@ int setFillRule(SBMLDocument* document, GraphicalObject* graphicalObject, const 
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingFillRule(document, getReactionId(graphicalObject), 0, fillRule);
         return setFillRule(style, fillRule);
     }
 
@@ -5283,6 +5473,7 @@ int setFillRule(SBMLDocument* document, const std::string& attribute, const std:
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingFillRule(document, attribute, 0, fillRule);
         return setFillRule(style, fillRule);
     }
 
@@ -6045,6 +6236,7 @@ int setGeometricShapeX(SBMLDocument* document, GraphicalObject* graphicalObject,
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeX(document, getReactionId(graphicalObject), 0, 0, x);
         return setGeometricShapeX(style, 0, x);
     }
 
@@ -6056,6 +6248,7 @@ int setGeometricShapeX(SBMLDocument* document, GraphicalObject* graphicalObject,
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeX(document, getReactionId(graphicalObject), 0, geometricShapeIndex, x);
         return setGeometricShapeX(style, geometricShapeIndex, x);
     }
 
@@ -6067,6 +6260,7 @@ int setGeometricShapeX(SBMLDocument* document, const std::string& attribute, con
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeX(document, attribute, 0, 0,x);
         return setGeometricShapeX(style, 0, x);
     }
 
@@ -6078,6 +6272,7 @@ int setGeometricShapeX(SBMLDocument* document, const std::string& attribute, uns
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeX(document, attribute, 0, geometricShapeIndex, x);
         return setGeometricShapeX(style, geometricShapeIndex, x);
     }
 
@@ -6089,6 +6284,7 @@ int setGeometricShapeXAsDouble(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeXAsDouble(document, getReactionId(graphicalObject), 0, 0, x);
         return setGeometricShapeXAsDouble(style, 0, x);
     }
 
@@ -6100,6 +6296,7 @@ int setGeometricShapeXAsDouble(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeXAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, x);
         return setGeometricShapeXAsDouble(style, geometricShapeIndex, x);
     }
 
@@ -6111,6 +6308,7 @@ int setGeometricShapeXAsDouble(SBMLDocument* document, const std::string& attrib
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeXAsDouble(document, attribute, 0, 0, x);
         return setGeometricShapeXAsDouble(style, 0, x);
     }
 
@@ -6122,6 +6320,7 @@ int setGeometricShapeXAsDouble(SBMLDocument* document, const std::string& attrib
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeX(document, attribute, 0, geometricShapeIndex, x);
         return setGeometricShapeXAsDouble(style, geometricShapeIndex, x);
     }
 
@@ -6273,6 +6472,7 @@ int setGeometricShapeY(SBMLDocument* document, GraphicalObject* graphicalObject,
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeY(document, getReactionId(graphicalObject), 0, 0, y);
         return setGeometricShapeY(style, 0, y);
     }
 
@@ -6284,6 +6484,7 @@ int setGeometricShapeY(SBMLDocument* document, GraphicalObject* graphicalObject,
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeY(document, getReactionId(graphicalObject), 0, geometricShapeIndex, y);
         return setGeometricShapeY(style, geometricShapeIndex, y);
     }
 
@@ -6295,6 +6496,7 @@ int setGeometricShapeY(SBMLDocument* document, const std::string& attribute, con
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeY(document, attribute, 0, 0, y);
         return setGeometricShapeY(style, 0, y);
     }
 
@@ -6306,6 +6508,7 @@ int setGeometricShapeY(SBMLDocument* document, const std::string& attribute, uns
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeY(document, attribute, 0, geometricShapeIndex, y);
         return setGeometricShapeY(style, geometricShapeIndex, y);
     }
 
@@ -6317,6 +6520,7 @@ int setGeometricShapeYAsDouble(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeYAsDouble(document, getReactionId(graphicalObject), 0, 0, y);
         return setGeometricShapeYAsDouble(style, 0, y);
     }
 
@@ -6328,6 +6532,7 @@ int setGeometricShapeYAsDouble(SBMLDocument* document, GraphicalObject* graphica
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeYAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, y);
         return setGeometricShapeYAsDouble(style, geometricShapeIndex, y);
     }
 
@@ -6339,6 +6544,7 @@ int setGeometricShapeYAsDouble(SBMLDocument* document, const std::string& attrib
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeYAsDouble(document, attribute, 0, 0, y);
         return setGeometricShapeYAsDouble(style, 0, y);
     }
 
@@ -6350,6 +6556,7 @@ int setGeometricShapeYAsDouble(SBMLDocument* document, const std::string& attrib
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeYAsDouble(document, attribute, 0, geometricShapeIndex, y);
         return setGeometricShapeYAsDouble(style, geometricShapeIndex, y);
     }
 
@@ -6501,6 +6708,7 @@ int setGeometricShapeWidth(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeWidth(document, getReactionId(graphicalObject), 0, 0, width);
         return setGeometricShapeWidth(style, 0, width);
     }
 
@@ -6512,6 +6720,7 @@ int setGeometricShapeWidth(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeWidth(document, getReactionId(graphicalObject), 0, geometricShapeIndex, width);
         return setGeometricShapeWidth(style, geometricShapeIndex, width);
     }
 
@@ -6523,6 +6732,7 @@ int setGeometricShapeWidth(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeWidth(document, attribute, 0, 0, width);
         return setGeometricShapeWidth(style, 0, width);
     }
 
@@ -6534,6 +6744,7 @@ int setGeometricShapeWidth(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeWidth(document, attribute, 0, geometricShapeIndex, width);
         return setGeometricShapeWidth(style, geometricShapeIndex, width);
     }
 
@@ -6545,6 +6756,7 @@ int setGeometricShapeWidthAsDouble(SBMLDocument* document, GraphicalObject* grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeWidthAsDouble(document, getReactionId(graphicalObject), 0, 0, width);
         return setGeometricShapeWidthAsDouble(style, 0, width);
     }
 
@@ -6556,6 +6768,7 @@ int setGeometricShapeWidthAsDouble(SBMLDocument* document, GraphicalObject* grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeWidthAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, width);
         return setGeometricShapeWidthAsDouble(style, geometricShapeIndex, width);
     }
 
@@ -6567,6 +6780,7 @@ int setGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& at
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeWidthAsDouble(document, attribute, 0, 0, width);
         return setGeometricShapeWidthAsDouble(style, 0, width);
     }
 
@@ -6578,6 +6792,7 @@ int setGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& at
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeWidthAsDouble(document, attribute, 0, geometricShapeIndex, width);
         return setGeometricShapeWidthAsDouble(style, geometricShapeIndex, width);
     }
 
@@ -6729,6 +6944,7 @@ int setGeometricShapeHeight(SBMLDocument* document, GraphicalObject* graphicalOb
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeHeight(document, getReactionId(graphicalObject), 0, 0, height);
         return setGeometricShapeHeight(style, 0, height);
     }
 
@@ -6740,6 +6956,7 @@ int setGeometricShapeHeight(SBMLDocument* document, GraphicalObject* graphicalOb
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeHeight(document, getReactionId(graphicalObject), 0, geometricShapeIndex, height);
         return setGeometricShapeHeight(style, geometricShapeIndex, height);
     }
 
@@ -6751,6 +6968,7 @@ int setGeometricShapeHeight(SBMLDocument* document, const std::string& attribute
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeHeight(document, attribute, 0, 0, height);
         return setGeometricShapeHeight(style, 0, height);
     }
 
@@ -6762,6 +6980,7 @@ int setGeometricShapeHeight(SBMLDocument* document, const std::string& attribute
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeHeight(document, attribute, 0, geometricShapeIndex, height);
         return setGeometricShapeHeight(style, geometricShapeIndex, height);
     }
 
@@ -6773,6 +6992,7 @@ int setGeometricShapeHeightAsDouble(SBMLDocument* document, GraphicalObject* gra
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeHeightAsDouble(document, getReactionId(graphicalObject), 0, 0, height);
         return setGeometricShapeHeightAsDouble(style, 0, height);
     }
 
@@ -6784,6 +7004,7 @@ int setGeometricShapeHeightAsDouble(SBMLDocument* document, GraphicalObject* gra
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeHeightAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, height);
         return setGeometricShapeHeightAsDouble(style, geometricShapeIndex, height);
     }
 
@@ -6795,6 +7016,7 @@ int setGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& a
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeHeightAsDouble(document, attribute, 0, 0, height);
         return setGeometricShapeHeightAsDouble(style, 0, height);
     }
 
@@ -6806,6 +7028,7 @@ int setGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& a
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeHeightAsDouble(document, attribute, 0, geometricShapeIndex, height);
         return setGeometricShapeHeightAsDouble(style, geometricShapeIndex, height);
     }
 
@@ -6939,6 +7162,7 @@ int setGeometricShapeRatio(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRatio(document, getReactionId(graphicalObject), 0, 0, ratio);
         return setGeometricShapeRatio(style, ratio);
     }
 
@@ -6950,6 +7174,7 @@ int setGeometricShapeRatio(SBMLDocument* document, GraphicalObject* graphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRatio(document, getReactionId(graphicalObject), 0, geometricShapeIndex, ratio);
         return setGeometricShapeRatio(style, geometricShapeIndex, ratio);
     }
 
@@ -6961,6 +7186,7 @@ int setGeometricShapeRatio(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRatio(document, attribute, 0, 0, ratio);
         return setGeometricShapeRatio(style, ratio);
     }
 
@@ -6972,6 +7198,7 @@ int setGeometricShapeRatio(SBMLDocument* document, const std::string& attribute,
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRatio(document, attribute, 0, geometricShapeIndex, ratio);
         return setGeometricShapeRatio(style, geometricShapeIndex, ratio);
     }
 
@@ -7076,6 +7303,7 @@ int setGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, GraphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, getReactionId(graphicalObject), 0, 0, rx);
         return setGeometricShapeCornerCurvatureRadiusX(style, rx);
     }
 
@@ -7087,6 +7315,7 @@ int setGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, GraphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, getReactionId(graphicalObject), 0, geometricShapeIndex, rx);
         return setGeometricShapeCornerCurvatureRadiusX(style, geometricShapeIndex, rx);
     }
 
@@ -7098,6 +7327,7 @@ int setGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, attribute, 0, 0, rx);
         return setGeometricShapeCornerCurvatureRadiusX(style, rx);
     }
 
@@ -7109,6 +7339,7 @@ int setGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, attribute, 0, geometricShapeIndex, rx);
         return setGeometricShapeCornerCurvatureRadiusX(style, geometricShapeIndex, rx);
     }
 
@@ -7120,6 +7351,7 @@ int setGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, Grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, getReactionId(graphicalObject), 0, 0, rx);
         return setGeometricShapeCornerCurvatureRadiusXAsDouble(style, rx);
     }
 
@@ -7131,6 +7363,7 @@ int setGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, Grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, rx);
         return setGeometricShapeCornerCurvatureRadiusXAsDouble(style, geometricShapeIndex, rx);
     }
 
@@ -7142,6 +7375,7 @@ int setGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, cons
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, attribute, 0, 0, rx);
         return setGeometricShapeCornerCurvatureRadiusXAsDouble(style, rx);
     }
 
@@ -7153,6 +7387,7 @@ int setGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, cons
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, attribute, 0, geometricShapeIndex, rx);
         return setGeometricShapeCornerCurvatureRadiusXAsDouble(style, geometricShapeIndex, rx);
     }
 
@@ -7304,6 +7539,7 @@ int setGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, GraphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, getReactionId(graphicalObject), 0, 0, ry);
         return setGeometricShapeCornerCurvatureRadiusY(style, ry);
     }
 
@@ -7315,6 +7551,7 @@ int setGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, GraphicalObj
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, getReactionId(graphicalObject), 0, geometricShapeIndex, ry);
         return setGeometricShapeCornerCurvatureRadiusY(style, geometricShapeIndex, ry);
     }
 
@@ -7326,6 +7563,7 @@ int setGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, attribute, 0, 0, ry);
         return setGeometricShapeCornerCurvatureRadiusY(style, ry);
     }
 
@@ -7337,6 +7575,7 @@ int setGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, attribute, 0, geometricShapeIndex, ry);
         return setGeometricShapeCornerCurvatureRadiusY(style, geometricShapeIndex, ry);
     }
 
@@ -7348,6 +7587,7 @@ int setGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, Grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, getReactionId(graphicalObject), 0, 0, ry);
         return setGeometricShapeCornerCurvatureRadiusYAsDouble(style, ry);
     }
 
@@ -7359,6 +7599,7 @@ int setGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, Grap
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, ry);
         return setGeometricShapeCornerCurvatureRadiusYAsDouble(style, geometricShapeIndex, ry);
     }
 
@@ -7370,6 +7611,7 @@ int setGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, cons
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, attribute, 0, 0, ry);
         return setGeometricShapeCornerCurvatureRadiusYAsDouble(style, ry);
     }
 
@@ -7381,6 +7623,7 @@ int setGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, cons
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, attribute, 0, geometricShapeIndex, ry);
         return setGeometricShapeCornerCurvatureRadiusYAsDouble(style, geometricShapeIndex, ry);
     }
 
@@ -7532,6 +7775,7 @@ int setGeometricShapeCenterX(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterX(document, getReactionId(graphicalObject), 0, 0, cx);
         return setGeometricShapeCenterX(style, cx);
     }
 
@@ -7543,6 +7787,7 @@ int setGeometricShapeCenterX(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterX(document, getReactionId(graphicalObject), 0, geometricShapeIndex, cx);
         return setGeometricShapeCenterX(style, geometricShapeIndex, cx);
     }
 
@@ -7554,6 +7799,7 @@ int setGeometricShapeCenterX(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterX(document, attribute, 0, 0, cx);
         return setGeometricShapeCenterX(style, cx);
     }
 
@@ -7565,6 +7811,7 @@ int setGeometricShapeCenterX(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterX(document, attribute, 0, geometricShapeIndex, cx);
         return setGeometricShapeCenterX(style, geometricShapeIndex, cx);
     }
 
@@ -7576,6 +7823,7 @@ int setGeometricShapeCenterXAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterXAsDouble(document, getReactionId(graphicalObject), 0, 0, cx);
         return setGeometricShapeCenterXAsDouble(style, cx);
     }
 
@@ -7587,6 +7835,7 @@ int setGeometricShapeCenterXAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterXAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, cx);
         return setGeometricShapeCenterXAsDouble(style, geometricShapeIndex, cx);
     }
 
@@ -7598,6 +7847,7 @@ int setGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterXAsDouble(document, attribute, 0, 0, cx);
         return setGeometricShapeCenterXAsDouble(style, cx);
     }
 
@@ -7609,6 +7859,7 @@ int setGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterXAsDouble(document, attribute, 0, geometricShapeIndex, cx);
         return setGeometricShapeCenterXAsDouble(style, geometricShapeIndex, cx);
     }
 
@@ -7760,6 +8011,7 @@ int setGeometricShapeCenterY(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterY(document, getReactionId(graphicalObject), 0, 0, cy);
         return setGeometricShapeCenterY(style, cy);
     }
 
@@ -7771,6 +8023,7 @@ int setGeometricShapeCenterY(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterY(document, getReactionId(graphicalObject), 0, geometricShapeIndex, cy);
         return setGeometricShapeCenterY(style, geometricShapeIndex, cy);
     }
 
@@ -7782,6 +8035,7 @@ int setGeometricShapeCenterY(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterY(document, attribute, 0, 0, cy);
         return setGeometricShapeCenterY(style, cy);
     }
 
@@ -7793,6 +8047,7 @@ int setGeometricShapeCenterY(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterY(document, attribute, 0, geometricShapeIndex, cy);
         return setGeometricShapeCenterY(style, geometricShapeIndex, cy);
     }
 
@@ -7804,6 +8059,7 @@ int setGeometricShapeCenterYAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterYAsDouble(document, getReactionId(graphicalObject), 0, 0, cy);
         return setGeometricShapeCenterYAsDouble(style, cy);
     }
 
@@ -7815,6 +8071,7 @@ int setGeometricShapeCenterYAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeCenterYAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, cy);
         return setGeometricShapeCenterYAsDouble(style, geometricShapeIndex, cy);
     }
 
@@ -7826,6 +8083,7 @@ int setGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterYAsDouble(document, attribute, 0, 0, cy);
         return setGeometricShapeCenterYAsDouble(style, cy);
     }
 
@@ -7837,6 +8095,7 @@ int setGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeCenterYAsDouble(document, attribute, 0, geometricShapeIndex, cy);
         return setGeometricShapeCenterYAsDouble(style, geometricShapeIndex, cy);
     }
 
@@ -7989,6 +8248,7 @@ int setGeometricShapeRadiusX(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusX(document, getReactionId(graphicalObject), 0, 0, rx);
         return setGeometricShapeRadiusX(style, rx);
     }
 
@@ -8000,6 +8260,7 @@ int setGeometricShapeRadiusX(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusX(document, getReactionId(graphicalObject), 0, geometricShapeIndex, rx);
         return setGeometricShapeRadiusX(style, geometricShapeIndex, rx);
     }
 
@@ -8011,6 +8272,7 @@ int setGeometricShapeRadiusX(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusX(document, attribute, 0, 0, rx);
         return setGeometricShapeRadiusX(style, rx);
     }
 
@@ -8022,6 +8284,7 @@ int setGeometricShapeRadiusX(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusX(document, attribute, 0, geometricShapeIndex, rx);
         return setGeometricShapeRadiusX(style, geometricShapeIndex, rx);
     }
 
@@ -8033,6 +8296,7 @@ int setGeometricShapeRadiusXAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusXAsDouble(document, getReactionId(graphicalObject), 0, 0, rx);
         return setGeometricShapeRadiusXAsDouble(style, rx);
     }
 
@@ -8044,6 +8308,7 @@ int setGeometricShapeRadiusXAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusXAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, rx);
         return setGeometricShapeRadiusXAsDouble(style, geometricShapeIndex, rx);
     }
 
@@ -8055,6 +8320,7 @@ int setGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusXAsDouble(document, attribute, 0, 0, rx);
         return setGeometricShapeRadiusXAsDouble(style, rx);
     }
 
@@ -8066,6 +8332,7 @@ int setGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusXAsDouble(document, attribute, 0, geometricShapeIndex, rx);
         return setGeometricShapeRadiusXAsDouble(style, geometricShapeIndex, rx);
     }
 
@@ -8217,6 +8484,7 @@ int setGeometricShapeRadiusY(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusY(document, getReactionId(graphicalObject), 0, 0, ry);
         return setGeometricShapeRadiusY(style, ry);
     }
 
@@ -8228,6 +8496,7 @@ int setGeometricShapeRadiusY(SBMLDocument* document, GraphicalObject* graphicalO
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusY(document, getReactionId(graphicalObject), 0, geometricShapeIndex, ry);
         return setGeometricShapeRadiusY(style, geometricShapeIndex, ry);
     }
 
@@ -8239,6 +8508,7 @@ int setGeometricShapeRadiusY(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusY(document, attribute, 0, 0, ry);
         return setGeometricShapeRadiusY(style, ry);
     }
 
@@ -8250,6 +8520,7 @@ int setGeometricShapeRadiusY(SBMLDocument* document, const std::string& attribut
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusY(document, attribute, 0, geometricShapeIndex, ry);
         return setGeometricShapeRadiusY(style, geometricShapeIndex, ry);
     }
 
@@ -8261,6 +8532,7 @@ int setGeometricShapeRadiusYAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusYAsDouble(document, getReactionId(graphicalObject), 0, 0, ry);
         return setGeometricShapeRadiusYAsDouble(style, ry);
     }
 
@@ -8272,6 +8544,7 @@ int setGeometricShapeRadiusYAsDouble(SBMLDocument* document, GraphicalObject* gr
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeRadiusYAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, ry);
         return setGeometricShapeRadiusYAsDouble(style, geometricShapeIndex, ry);
     }
 
@@ -8283,6 +8556,7 @@ int setGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusYAsDouble(document, attribute, 0, 0, ry);
         return setGeometricShapeRadiusYAsDouble(style, ry);
     }
 
@@ -8294,6 +8568,7 @@ int setGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& 
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeRadiusYAsDouble(document, attribute, 0, geometricShapeIndex, ry);
         return setGeometricShapeRadiusYAsDouble(style, geometricShapeIndex, ry);
     }
 
@@ -8460,6 +8735,7 @@ int setGeometricShapeElementX(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementX(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeElementX(style, x);
     }
 
@@ -8471,6 +8747,7 @@ int setGeometricShapeElementX(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementX(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeElementX(style, elementIndex, x);
     }
 
@@ -8482,6 +8759,7 @@ int setGeometricShapeElementX(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementX(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeElementX(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -8493,6 +8771,7 @@ int setGeometricShapeElementX(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementX(document, attribute, 0, 0, 0, x);
         return setGeometricShapeElementX(style, x);
     }
 
@@ -8504,6 +8783,7 @@ int setGeometricShapeElementX(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementX(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeElementX(style, elementIndex, x);
     }
 
@@ -8515,6 +8795,7 @@ int setGeometricShapeElementX(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementX(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeElementX(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -8526,6 +8807,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeElementXAsDouble(style, x);
     }
 
@@ -8537,6 +8819,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeElementXAsDouble(style, elementIndex, x);
     }
 
@@ -8548,6 +8831,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeElementXAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -8559,6 +8843,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, attribute, 0, 0, 0, x);
         return setGeometricShapeElementXAsDouble(style, x);
     }
 
@@ -8570,6 +8855,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeElementXAsDouble(style, elementIndex, x);
     }
 
@@ -8581,6 +8867,7 @@ int setGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementXAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeElementXAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -8716,6 +9003,7 @@ int setGeometricShapeElementY(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementY(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeElementY(style, y);
     }
     return -1;
@@ -8726,6 +9014,7 @@ int setGeometricShapeElementY(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementY(document, getReactionId(graphicalObject), 0, 0, elementIndex, y);
         return setGeometricShapeElementY(style, elementIndex, y);
     }
     return -1;
@@ -8736,6 +9025,7 @@ int setGeometricShapeElementY(SBMLDocument* document, GraphicalObject* graphical
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementY(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeElementY(style, geometricShapeIndex, elementIndex, y);
     }
     return -1;
@@ -8746,6 +9036,7 @@ int setGeometricShapeElementY(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementY(document, attribute, 0, 0, 0, y);
         return setGeometricShapeElementY(style, y);
     }
     return -1;
@@ -8756,6 +9047,7 @@ int setGeometricShapeElementY(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementY(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeElementY(style, elementIndex, y);
     }
     return -1;
@@ -8766,6 +9058,7 @@ int setGeometricShapeElementY(SBMLDocument* document, const std::string& attribu
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementY(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeElementY(style, geometricShapeIndex, elementIndex, y);
     }
     return -1;
@@ -8776,6 +9069,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeElementYAsDouble(style, y);
     }
     return -1;
@@ -8786,6 +9080,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, y);
         return setGeometricShapeElementYAsDouble(style, elementIndex, y);
     }
     return -1;
@@ -8796,6 +9091,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, GraphicalObject* g
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeElementYAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
     return -1;
@@ -8806,6 +9102,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, attribute, 0, 0, 0, y);
         return setGeometricShapeElementYAsDouble(style, y);
     }
     return -1;
@@ -8816,6 +9113,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeElementYAsDouble(style, elementIndex, y);
     }
     return -1;
@@ -8826,6 +9124,7 @@ int setGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string&
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeElementYAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeElementYAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
     return -1;
@@ -8960,6 +9259,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeBasePoint1X(style, x);
     }
     return -1;
@@ -8970,6 +9270,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint1X(style, elementIndex, x);
     }
     return -1;
@@ -8980,6 +9281,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint1X(style, geometricShapeIndex, elementIndex, x);
     }
     return -1;
@@ -8990,6 +9292,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, attribute, 0, 0, 0, x);
         return setGeometricShapeBasePoint1X(style, x);
     }
     return -1;
@@ -9000,6 +9303,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint1X(style, elementIndex, x);
     }
     return -1;
@@ -9010,6 +9314,7 @@ int setGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1X(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint1X(style, geometricShapeIndex, elementIndex, x);
     }
     return -1;
@@ -9020,6 +9325,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeBasePoint1XAsDouble(style, x);
     }
     return -1;
@@ -9030,6 +9336,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint1XAsDouble(style, elementIndex, x);
     }
     return -1;
@@ -9040,6 +9347,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint1XAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
     return -1;
@@ -9050,6 +9358,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, attribute, 0, 0, 0, x);
         return setGeometricShapeBasePoint1XAsDouble(style, x);
     }
     return -1;
@@ -9060,6 +9369,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint1XAsDouble(style, elementIndex, x);
     }
     return -1;
@@ -9070,6 +9380,7 @@ int setGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1XAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint1XAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
     return -1;
@@ -9218,6 +9529,7 @@ int setGeometricShapeBasePoint1Y(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1Y(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeBasePoint1Y(style, elementIndex, y);
     }
 
@@ -9229,6 +9541,7 @@ int setGeometricShapeBasePoint1Y(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1Y(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint1Y(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9240,6 +9553,7 @@ int setGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1Y(document, attribute, 0, 0, 0, y);
         return setGeometricShapeBasePoint1Y(style, y);
     }
 
@@ -9251,6 +9565,7 @@ int setGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1Y(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint1Y(style, elementIndex, y);
     }
 
@@ -9262,6 +9577,7 @@ int setGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1Y(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint1Y(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9273,6 +9589,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeBasePoint1YAsDouble(style, y);
     }
 
@@ -9284,6 +9601,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint1YAsDouble(style, elementIndex, y);
     }
 
@@ -9295,6 +9613,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint1YAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9306,6 +9625,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, attribute, 0, 0, 0, y);
         return setGeometricShapeBasePoint1YAsDouble(style, y);
     }
 
@@ -9317,6 +9637,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint1YAsDouble(style, elementIndex, y);
     }
 
@@ -9328,6 +9649,7 @@ int setGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint1YAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint1YAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9466,6 +9788,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeBasePoint2X(style, x);
     }
 
@@ -9477,6 +9800,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint2X(style, elementIndex, x);
     }
 
@@ -9488,6 +9812,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint2X(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -9499,6 +9824,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, attribute, 0, 0, 0, x);
         return setGeometricShapeBasePoint2X(style, x);
     }
 
@@ -9510,6 +9836,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint2X(style, elementIndex, x);
     }
 
@@ -9521,6 +9848,7 @@ int setGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2X(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint2X(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -9532,6 +9860,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, x);
         return setGeometricShapeBasePoint2XAsDouble(style, x);
     }
 
@@ -9543,6 +9872,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint2XAsDouble(style, elementIndex, x);
     }
 
@@ -9554,6 +9884,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint2XAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -9565,6 +9896,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, attribute, 0, 0, 0, x);
         return setGeometricShapeBasePoint2XAsDouble(style, x);
     }
 
@@ -9576,6 +9908,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, attribute, 0, 0, elementIndex, x);
         return setGeometricShapeBasePoint2XAsDouble(style, elementIndex, x);
     }
 
@@ -9587,6 +9920,7 @@ int setGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2XAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, x);
         return setGeometricShapeBasePoint2XAsDouble(style, geometricShapeIndex, elementIndex, x);
     }
 
@@ -9725,6 +10059,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeBasePoint2Y(style, y);
     }
 
@@ -9736,6 +10071,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, getReactionId(graphicalObject), 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint2Y(style, elementIndex, y);
     }
 
@@ -9747,6 +10083,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, GraphicalObject* graphi
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint2Y(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9758,6 +10095,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, attribute, 0, 0, 0, y);
         return setGeometricShapeBasePoint2Y(style, y);
     }
 
@@ -9769,6 +10107,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint2Y(style, elementIndex, y);
     }
 
@@ -9780,6 +10119,7 @@ int setGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& attr
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2Y(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint2Y(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9791,6 +10131,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, getReactionId(graphicalObject), 0, 0, 0, y);
         return setGeometricShapeBasePoint2YAsDouble(style, y);
     }
 
@@ -9802,6 +10143,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, getReactionId(graphicalObject), 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint2YAsDouble(style, elementIndex, y);
     }
 
@@ -9813,6 +10155,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, GraphicalObject
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, getReactionId(graphicalObject), 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint2YAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
 
@@ -9824,6 +10167,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, attribute, 0, 0, 0, y);
         return setGeometricShapeBasePoint2YAsDouble(style, y);
     }
 
@@ -9835,6 +10179,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, attribute, 0, 0, elementIndex, y);
         return setGeometricShapeBasePoint2YAsDouble(style, elementIndex, y);
     }
 
@@ -9846,6 +10191,7 @@ int setGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::stri
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
+        setReactionLineEndingGeometricShapeBasePoint2YAsDouble(document, attribute, 0, geometricShapeIndex, elementIndex, y);
         return setGeometricShapeBasePoint2YAsDouble(style, geometricShapeIndex, elementIndex, y);
     }
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -850,6 +850,7 @@ LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLine
     if (localLineEnding && globalLineEnding) {
         localLineEnding->setGroup(globalLineEnding->getGroup()->clone());
         localLineEnding->setBoundingBox(globalLineEnding->getBoundingBox()->clone());
+        localLineEnding->getBoundingBox()->setId(localLineEnding->getId() + "_bb");
     }
 
     return localLineEnding;
@@ -953,6 +954,20 @@ int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned i
     return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
 }
 
+int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxX(document, reactionId, reactionGlyphIndex, i, x);
+
+    return 0;
+}
+
+int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxX(document, layoutIndex, reactionId, reactionGlyphIndex, i, x);
+
+    return 0;
+}
+
 const double getLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid) {
     return getPositionY(getLineEndingBoundingBox(document, sid));
 }
@@ -983,6 +998,20 @@ int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std:
 
 int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
     return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
+}
+
+int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxY(document, reactionId, reactionGlyphIndex, i, y);
+
+    return 0;
+}
+
+int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxY(document, layoutIndex, reactionId, reactionGlyphIndex, i, y);
+
+    return 0;
 }
 
 const double getLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid) {
@@ -1019,6 +1048,20 @@ int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsign
     return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
 }
 
+int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, i, width);
+
+    return 0;
+}
+
+int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, width);
+
+    return 0;
+}
+
 const double getLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid) {
     return getDimensionHeight(getLineEndingBoundingBox(document, sid));
 }
@@ -1051,6 +1094,20 @@ int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const
 
 int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
     return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
+}
+
+int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, i, height);
+
+    return 0;
+}
+
+int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingBoundingBoxHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, height);
+
+    return 0;
 }
 
 RenderGroup* getLineEndingRenderGroup(SBMLDocument* document, const std::string& sid) {
@@ -1110,6 +1167,20 @@ int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned in
     return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
+int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeColor(document, reactionId, reactionGlyphIndex, i, strokeColor);
+
+    return 0;
+}
+
+int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeColor);
+
+    return 0;
+}
+
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
     return isSetStrokeWidth(getLineEndingRenderGroup(document, id));
 }
@@ -1156,6 +1227,20 @@ int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::
 
 int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
     return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
+}
+
+int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeWidth(document, reactionId, reactionGlyphIndex, i, strokeWidth);
+
+    return 0;
+}
+
+int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, strokeWidth);
+
+    return 0;
 }
 
 bool isSetLineEndingStrokeDashArray(SBMLDocument* document, const std::string& id) {
@@ -1238,6 +1323,20 @@ int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int
     return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
 }
 
+int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeDash(document, reactionId, reactionGlyphIndex, i, dashIndex, dash);
+
+    return 0;
+}
+
+int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingStrokeDash(document, layoutIndex, reactionId, reactionGlyphIndex, i, dashIndex, dash);
+
+    return 0;
+}
+
 bool isSetLineEndingFillColor(SBMLDocument* document, const std::string& id) {
     return isSetFillColor(getLineEndingRenderGroup(document, id));
 }
@@ -1302,6 +1401,34 @@ int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, uns
     return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
+int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillColor(document, reactionId, reactionGlyphIndex, i, fillColor);
+
+    return 0;
+}
+
+int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillColor(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillColor);
+
+    return 0;
+}
+
+int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillColorAsGradient(document, reactionId, reactionGlyphIndex, i, gradientType, stopsVector);
+
+    return 0;
+}
+
+int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillColorAsGradient(document, layoutIndex, reactionId, reactionGlyphIndex, i, gradientType, stopsVector);
+
+    return 0;
+}
+
 bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
     return isSetFillRule(getLineEndingRenderGroup(document, id));
 }
@@ -1348,6 +1475,20 @@ int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::str
 
 int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
     return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
+}
+
+int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillRule(document, reactionId, reactionGlyphIndex, i, fillRule);
+
+    return 0;
+}
+
+int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingFillRule(document, layoutIndex, reactionId, reactionGlyphIndex, i, fillRule);
+
+    return 0;
 }
 
 unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, const std::string& id) {
@@ -1530,6 +1671,20 @@ int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigne
     return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
+int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, x);
 }
@@ -1544,6 +1699,20 @@ int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document,
 
 int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
+}
+
+int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, x);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1616,6 +1785,20 @@ int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigne
     return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
+int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, y);
 }
@@ -1630,6 +1813,20 @@ int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document,
 
 int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
+}
+
+int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, y);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1700,6 +1897,20 @@ int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, uns
     return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
+int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, width);
 }
@@ -1714,6 +1925,20 @@ int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* docum
 
 int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
+}
+
+int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, width);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1784,6 +2009,20 @@ int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, un
     return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
+int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, height);
 }
@@ -1798,6 +2037,20 @@ int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* docu
 
 int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
+}
+
+int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, height);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1846,6 +2099,20 @@ int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, con
 
 int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
     return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
+}
+
+int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRatio(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRatio(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, ratio);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1916,6 +2183,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocume
     return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
@@ -1930,6 +2211,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SB
 
 int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2000,6 +2295,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocume
     return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& cornerCurvatureRadiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
@@ -2014,6 +2323,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SB
 
 int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2084,6 +2407,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, u
     return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
+int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, centerX);
 }
@@ -2098,6 +2435,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* doc
 
 int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
+}
+
+int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerX);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2168,6 +2519,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, u
     return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
+int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, centerY);
 }
@@ -2182,6 +2547,20 @@ int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* doc
 
 int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
+}
+
+int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, centerY);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2252,6 +2631,20 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, u
     return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
+int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, radiusX);
 }
@@ -2266,6 +2659,20 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* doc
 
 int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
+}
+
+int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusX);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2336,6 +2743,20 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, u
     return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
+int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, radiusY);
 }
@@ -2350,6 +2771,20 @@ int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* doc
 
 int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
+}
+
+int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, radiusY);
+
+    return 0;
 }
 
 const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2436,6 +2871,20 @@ int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, 
     return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
+int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, x);
 }
@@ -2450,6 +2899,20 @@ int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* do
 
 int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
+}
+
+int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, x);
+
+    return 0;
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2504,6 +2967,20 @@ int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, 
     return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
+int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, y);
 }
@@ -2518,6 +2995,20 @@ int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* do
 
 int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
+}
+
+int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, y);
+
+    return 0;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2572,6 +3063,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* documen
     return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
+int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
@@ -2586,6 +3091,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument*
 
 int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1X);
+
+    return 0;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2640,6 +3159,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* documen
     return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
+int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
@@ -2654,6 +3187,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument*
 
 int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint1Y);
+
+    return 0;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2708,6 +3255,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* documen
     return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
+int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
@@ -2722,6 +3283,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument*
 
 int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2X);
+
+    return 0;
 }
 
 const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2776,6 +3351,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* documen
     return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
+int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+
+    return 0;
+}
+
 int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getLineEndingRenderGroup(document, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
@@ -2790,6 +3379,20 @@ int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument*
 
 int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, elementIndex, basePoint2Y);
+
+    return 0;
 }
 
 bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2838,6 +3441,20 @@ int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, cons
 
 int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
+}
+
+int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHref(document, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href);
+
+    return 0;
+}
+
+int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href) {
+    for (unsigned int i = 0; i < getNumSpeciesReferenceGlyphs(document, reactionId, reactionGlyphIndex); i++)
+        setSpeciesReferenceLineEndingGeometricShapeHref(document, layoutIndex, reactionId, reactionGlyphIndex, i, geometricShapeIndex, href);
+
+    return 0;
 }
 
 Style* getStyle(SBMLDocument* document, GraphicalObject* graphicalObject) {

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -855,11 +855,11 @@ LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLine
     return localLineEnding;
 }
 
-LineEnding* getReactionLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-LineEnding* getReactionLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
     SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     LineEnding* lineEnding = getLineEnding(document, getStartHead(document, speciesReferenceGlyph));
     if (!lineEnding)
@@ -873,7 +873,7 @@ LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std
 }
 
 LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    LineEnding* lineEnding = getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    LineEnding* lineEnding = getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     if(!isLocal(document, lineEnding, speciesReferenceGlyph))
         lineEnding = createLocalLineEnding(document, lineEnding, speciesReferenceGlyph);
@@ -913,12 +913,12 @@ BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int rende
     return getLineEndingBoundingBox(getLineEnding(document, renderIndex, sid));
 }
 
-BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEndingBoundingBox(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingBoundingBox(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getLineEndingBoundingBox(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getLineEndingBoundingBox(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 const double getLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid) {
@@ -929,12 +929,12 @@ const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int rend
     return getPositionX(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionX(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
-const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionX(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid, double x) {
@@ -945,11 +945,11 @@ int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionX(getLineEndingBoundingBox(document, renderIndex, sid), x);
 }
 
-int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
     return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
 }
 
-int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
     return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
 }
 
@@ -961,12 +961,12 @@ const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int rend
     return getPositionY(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionY(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
-const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionY(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid, double y) {
@@ -977,11 +977,11 @@ int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionY(getLineEndingBoundingBox(document, renderIndex, sid), y);
 }
 
-int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
     return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
 }
 
-int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
     return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
 }
 
@@ -993,13 +993,13 @@ const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int 
     return getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionWidth(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                       speciesReferenceIndex));
 }
 
-const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionWidth(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                       speciesReferenceIndex));
 }
 
@@ -1011,11 +1011,11 @@ int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderInd
     return setDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid), width);
 }
 
-int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
     return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
 }
 
-int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
     return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
 }
 
@@ -1027,13 +1027,13 @@ const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int
     return getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionHeight(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                        speciesReferenceIndex));
 }
 
-const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionHeight(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                        speciesReferenceIndex));
 }
 
@@ -1045,11 +1045,11 @@ int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIn
     return setDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid), height);
 }
 
-int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
     return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
 }
 
-int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
     return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
 }
 
@@ -1069,12 +1069,12 @@ bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex
     return isSetStrokeColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetReactionLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetStrokeColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingStrokeColor(SBMLDocument* document, const std::string& id) {
@@ -1086,12 +1086,12 @@ const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int 
 }
 
 
-const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getStrokeColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, const std::string& id, const std::string& strokeColor) {
@@ -1102,12 +1102,12 @@ int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, c
     return setStrokeColor(getLineEndingRenderGroup(document, renderIndex, id), addColor(document, getLineEnding(document, renderIndex, id), strokeColor));
 }
 
-int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
+int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
-int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
+int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1118,12 +1118,12 @@ bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex
     return isSetStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetReactionLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetStrokeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const double getLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1134,12 +1134,12 @@ const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int rende
     return getStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const double getReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const double getReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getStrokeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingStrokeWidth(SBMLDocument* document, const std::string& id, double strokeWidth) {
@@ -1150,11 +1150,11 @@ int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, c
     return setStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id), strokeWidth);
 }
 
-int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
     return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
 }
 
-int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
     return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
 }
 
@@ -1190,12 +1190,12 @@ unsigned int getNumLineEndingStrokeDashes(SBMLDocument* document, unsigned int r
     return getNumStrokeDashes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumReactionLineEndingStrokeDashes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumSpeciesReferenceLineEndingStrokeDashes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumStrokeDashes(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumStrokeDashes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 unsigned int getLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dashIndex) {
@@ -1206,12 +1206,12 @@ unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int render
     return getStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex);
 }
 
-unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
-    return getReactionLineEndingStrokeDash(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, dashIndex);
+unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getSpeciesReferenceLineEndingStrokeDash(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, dashIndex);
 }
 
-unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
-    return getStrokeDash(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex);
+unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getStrokeDash(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex);
 }
 
 int setLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dash) {
@@ -1230,11 +1230,11 @@ int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, co
     return setStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex, dash);
 }
 
-int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
     return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
 }
 
-int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
     return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
 }
 
@@ -1246,12 +1246,12 @@ bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, 
     return isSetFillColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetReactionLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetFillColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingFillColor(SBMLDocument* document, const std::string& id) {
@@ -1262,12 +1262,12 @@ const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int re
     return getFillColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getFillColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fillColor) {
@@ -1286,20 +1286,20 @@ int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int render
     return setFillColorAsGradient(getLineEndingRenderGroup(document, renderIndex, id), addGradient(document, getLineEnding(document, renderIndex, id), gradientType, stopsVector));
 }
 
-int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
 }
 
-int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
-    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
+int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
-int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
 }
 
-int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
-    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
+int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
 bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -1310,12 +1310,12 @@ bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, c
     return isSetFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetReactionLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetFillRule(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -1326,12 +1326,12 @@ const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int ren
     return getFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getReactionLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getFillRule(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingFillRule(SBMLDocument* document, const std::string& id, const std::string& fillRule) {
@@ -1342,11 +1342,11 @@ int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, cons
     return setFillRule(getLineEndingRenderGroup(document, renderIndex, id), fillRule);
 }
 
-int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
     return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
 }
 
-int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
     return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
 }
 
@@ -1358,12 +1358,12 @@ unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned in
     return getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumReactionLineEndingGeometricShapes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumSpeciesReferenceLineEndingGeometricShapes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumGeometricShapes(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumGeometricShapes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 bool isLineEndingRectangle(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1374,12 +1374,12 @@ bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, con
     return isRectangle(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isReactionLineEndingRectangle(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSpeciesReferenceLineEndingRectangle(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isReactionLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRectangle(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRectangle(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingEllipse(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1390,12 +1390,12 @@ bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const
     return isEllipse(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isEllipse(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isReactionLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isEllipse(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingPolygon(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1406,12 +1406,12 @@ bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const
     return isPolygon(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isPolygon(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isReactionLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isPolygon(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingImage(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1422,12 +1422,12 @@ bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const s
     return isImage(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isImage(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isReactionLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isImage(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingRenderCurve(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1438,12 +1438,12 @@ bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, c
     return isRenderCurve(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRenderCurve(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isReactionLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRenderCurve(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingText(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1454,12 +1454,12 @@ bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const st
     return isText(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isReactionLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isText(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isReactionLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isText(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isSetLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1470,12 +1470,12 @@ bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderI
     return isSetGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1486,12 +1486,12 @@ const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned
     return getGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeX(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1504,14 +1504,14 @@ const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsign
     return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
 }
 
-const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector xVector = getReactionLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
+const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
 }
 
-const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector xVector = getReactionLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
+const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
 }
 
 int setLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& x) {
@@ -1522,11 +1522,11 @@ int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderInde
     return setGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
     return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
     return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
@@ -1538,11 +1538,11 @@ int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int re
     return setGeometricShapeXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
@@ -1554,12 +1554,12 @@ bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderI
     return isSetGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1570,12 +1570,12 @@ const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned
     return getGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 
@@ -1589,14 +1589,14 @@ const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsign
     return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
 }
 
-const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector yVector = getReactionLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
 }
 
-const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector yVector = getReactionLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
 }
 
 
@@ -1608,11 +1608,11 @@ int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderInde
     return setGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
@@ -1624,11 +1624,11 @@ int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int re
     return setGeometricShapeYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
@@ -1640,12 +1640,12 @@ bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int ren
     return isSetGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1656,12 +1656,12 @@ const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsi
     return getGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1674,14 +1674,14 @@ const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, un
     return getAbsoluteValue(widthVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(widthVector);
 }
 
-const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector widthVector = getReactionLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
+const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
 }
 
-const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector widthVector = getReactionLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
+const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
 }
 
 int setLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& width) {
@@ -1692,11 +1692,11 @@ int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int render
     return setGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
 }
 
-int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
     return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
-int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
     return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
@@ -1708,11 +1708,11 @@ int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned in
     return setGeometricShapeWidthAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
 }
 
-int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
-int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
@@ -1724,12 +1724,12 @@ bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int re
     return isSetGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeHeight(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1740,12 +1740,12 @@ const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, uns
     return getGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1758,14 +1758,14 @@ const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, u
     return getAbsoluteValue(heightVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(heightVector);
 }
 
-const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector heightVector = getReactionLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
+const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
 }
 
-const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector heightVector = getReactionLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
+const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
 }
 
 int setLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& height) {
@@ -1776,11 +1776,11 @@ int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int rende
     return setGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
 }
 
-int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
     return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
-int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
     return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
@@ -1792,11 +1792,11 @@ int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned i
     return setGeometricShapeHeightAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
 }
 
-int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
-int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
@@ -1808,12 +1808,12 @@ bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int ren
     return isSetGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRatio(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1824,12 +1824,12 @@ const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned i
     return getGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRatio(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 int setLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, double ratio) {
@@ -1840,11 +1840,11 @@ int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int render
     return setGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, ratio);
 }
 
-int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
     return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
 }
 
-int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
     return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
 }
 
@@ -1856,12 +1856,12 @@ bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document,
     return isSetGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1872,12 +1872,12 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1890,14 +1890,14 @@ const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocum
     return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusXVector);
 }
 
-const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
-const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusX) {
@@ -1908,11 +1908,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -1924,11 +1924,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* docu
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -1940,12 +1940,12 @@ bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document,
     return isSetGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1956,12 +1956,12 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1974,14 +1974,14 @@ const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocum
     return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusYVector);
 }
 
-const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
-const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusY) {
@@ -1992,11 +1992,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2008,11 +2008,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* docu
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2024,12 +2024,12 @@ bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCenterX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2040,12 +2040,12 @@ const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, un
     return getGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCenterX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2058,14 +2058,14 @@ const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
 }
 
-const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerX = getReactionLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
+const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
 }
 
-const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerX = getReactionLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
+const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
 }
 
 int setLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
@@ -2076,11 +2076,11 @@ int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
 }
 
-int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
     return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
-int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
     return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
@@ -2092,11 +2092,11 @@ int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeCenterXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
 }
 
-int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
-int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
@@ -2108,12 +2108,12 @@ bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCenterY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2124,12 +2124,12 @@ const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, un
     return getGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCenterY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2142,14 +2142,14 @@ const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
 }
 
-const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerY = getReactionLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
+const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
 }
 
-const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerY = getReactionLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
+const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
 }
 
 int setLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
@@ -2160,11 +2160,11 @@ int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
 }
 
-int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
     return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
-int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
     return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
@@ -2176,11 +2176,11 @@ int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeCenterYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
 }
 
-int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
-int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
@@ -2192,12 +2192,12 @@ bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2208,12 +2208,12 @@ const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, un
     return getGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2226,14 +2226,14 @@ const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(rXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(rXVector);
 }
 
-const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getReactionLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
-const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getReactionLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
@@ -2244,11 +2244,11 @@ int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -2260,11 +2260,11 @@ int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -2276,12 +2276,12 @@ bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2292,12 +2292,12 @@ const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, un
     return getGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2310,14 +2310,14 @@ const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(rYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(rYVector);
 }
 
-const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getReactionLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
-const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getReactionLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
@@ -2328,11 +2328,11 @@ int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2344,11 +2344,11 @@ int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2360,12 +2360,12 @@ const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document
     return getGeometricShapeNumElements(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeNumElements(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeNumElements(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeNumElements(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2376,12 +2376,12 @@ bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsign
     return isRenderCubicBezier(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return isReactionLineEndingGeometricShapeElementCubicBezier(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return isRenderCubicBezier(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isRenderCubicBezier(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2392,12 +2392,12 @@ const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, u
     return getGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeElementX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeElementX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeElementX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2410,14 +2410,14 @@ const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document,
     return getAbsoluteValue(elementXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(elementXVector);
 }
 
-const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector x = getReactionLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(x) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
+const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
 }
 
-const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector x = getReactionLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(x) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
+const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
 }
 
 int setLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
@@ -2428,11 +2428,11 @@ int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
     return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
     return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
@@ -2444,11 +2444,11 @@ int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned
     return setGeometricShapeElementXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
-int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
@@ -2460,12 +2460,12 @@ const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, u
     return getGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeElementY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeElementY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeElementY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2478,14 +2478,14 @@ const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document,
     return getAbsoluteValue(elementYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(elementYVector);
 }
 
-const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector y = getReactionLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
+const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
 }
 
-const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector y = getReactionLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
+const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
 }
 
 int setLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
@@ -2496,11 +2496,11 @@ int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
     return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
     return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
@@ -2512,11 +2512,11 @@ int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned
     return setGeometricShapeElementYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
-int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
@@ -2528,12 +2528,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document
     return getGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeBasePoint1X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint1X(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2546,14 +2546,14 @@ const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint1XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint1XVector);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1X = getReactionLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1X = getReactionLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
 }
 
 int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
@@ -2564,11 +2564,11 @@ int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
     return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
     return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
@@ -2580,11 +2580,11 @@ int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint1XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
@@ -2596,12 +2596,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document
     return getGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeBasePoint1Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint1Y(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2614,14 +2614,14 @@ const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint1YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint1YVector);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1Y = getReactionLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1Y = getReactionLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
 }
 
 int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
@@ -2632,11 +2632,11 @@ int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
     return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
     return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
@@ -2648,11 +2648,11 @@ int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint1YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
@@ -2664,12 +2664,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document
     return getGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeBasePoint2X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint2X(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2682,14 +2682,14 @@ const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint2XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint2XVector);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2X = getReactionLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2X = getReactionLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
 }
 
 int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
@@ -2700,11 +2700,11 @@ int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
     return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
     return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
@@ -2716,11 +2716,11 @@ int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint2XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
@@ -2732,11 +2732,11 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document
     return getGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getReactionLineEndingGeometricShapeBasePoint2Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     return getGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
@@ -2750,14 +2750,14 @@ const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint2YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint2YVector);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2Y = getReactionLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
 }
 
-const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2Y = getReactionLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
+const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
 }
 
 int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
@@ -2768,11 +2768,11 @@ int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
     return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
     return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
@@ -2784,11 +2784,11 @@ int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint2YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
@@ -2800,12 +2800,12 @@ bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int rend
     return isSetGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetReactionLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeHref(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2816,12 +2816,12 @@ const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsign
     return getGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getReactionLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHref(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 int setLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const std::string& href) {
@@ -2832,11 +2832,11 @@ int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderI
     return setGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, href);
 }
 
-int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
 }
 
-int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
 }
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -855,11 +855,11 @@ LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLine
     return localLineEnding;
 }
 
-LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+LineEnding* getReactionLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEnding(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+LineEnding* getReactionLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
     SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     LineEnding* lineEnding = getLineEnding(document, getStartHead(document, speciesReferenceGlyph));
     if (!lineEnding)
@@ -873,7 +873,7 @@ LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std
 }
 
 LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    LineEnding* lineEnding = getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    LineEnding* lineEnding = getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     SpeciesReferenceGlyph* speciesReferenceGlyph = getSpeciesReferenceGlyph(document, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     if(!isLocal(document, lineEnding, speciesReferenceGlyph))
         lineEnding = createLocalLineEnding(document, lineEnding, speciesReferenceGlyph);
@@ -913,12 +913,12 @@ BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int rende
     return getLineEndingBoundingBox(getLineEnding(document, renderIndex, sid));
 }
 
-BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEndingBoundingBox(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEndingBoundingBox(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getLineEndingBoundingBox(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getLineEndingBoundingBox(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 const double getLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid) {
@@ -929,12 +929,12 @@ const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int rend
     return getPositionX(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionX(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionX(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid, double x) {
@@ -945,11 +945,11 @@ int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionX(getLineEndingBoundingBox(document, renderIndex, sid), x);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
     return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
+int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x) {
     return setPositionX(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), x);
 }
 
@@ -961,12 +961,12 @@ const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int rend
     return getPositionY(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getPositionY(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
+const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getPositionY(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 int setLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid, double y) {
@@ -977,11 +977,11 @@ int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, 
     return setPositionY(getLineEndingBoundingBox(document, renderIndex, sid), y);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
     return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
+int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y) {
     return setPositionY(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), y);
 }
 
@@ -993,13 +993,13 @@ const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int 
     return getDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                       speciesReferenceIndex));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionWidth(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionWidth(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                       speciesReferenceIndex));
 }
 
@@ -1011,11 +1011,11 @@ int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderInd
     return setDimensionWidth(getLineEndingBoundingBox(document, renderIndex, sid), width);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
     return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
+int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width) {
     return setDimensionWidth(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), width);
 }
 
@@ -1027,13 +1027,13 @@ const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int
     return getDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                        speciesReferenceIndex));
 }
 
-const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getDimensionHeight(getSpeciesReferenceLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
+const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getDimensionHeight(getReactionLineEndingBoundingBox(document, reactionId, reactionGlyphIndex,
                                                                        speciesReferenceIndex));
 }
 
@@ -1045,11 +1045,11 @@ int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIn
     return setDimensionHeight(getLineEndingBoundingBox(document, renderIndex, sid), height);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
     return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
 }
 
-int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
+int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height) {
     return setDimensionHeight(getLineEndingBoundingBox(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), height);
 }
 
@@ -1069,12 +1069,12 @@ bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex
     return isSetStrokeColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetReactionLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingStrokeColor(SBMLDocument* document, const std::string& id) {
@@ -1086,12 +1086,12 @@ const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int 
 }
 
 
-const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEndingStrokeColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getStrokeColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, const std::string& id, const std::string& strokeColor) {
@@ -1102,12 +1102,12 @@ int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, c
     return setStrokeColor(getLineEndingRenderGroup(document, renderIndex, id), addColor(document, getLineEnding(document, renderIndex, id), strokeColor));
 }
 
-int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
+int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
-int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
+int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1118,12 +1118,12 @@ bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex
     return isSetStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetReactionLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetStrokeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const double getLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1134,12 +1134,12 @@ const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int rende
     return getStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const double getReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEndingStrokeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getStrokeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const double getReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getStrokeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingStrokeWidth(SBMLDocument* document, const std::string& id, double strokeWidth) {
@@ -1150,11 +1150,11 @@ int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, c
     return setStrokeWidth(getLineEndingRenderGroup(document, renderIndex, id), strokeWidth);
 }
 
-int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
     return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
 }
 
-int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
+int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth) {
     return setStrokeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeWidth);
 }
 
@@ -1190,12 +1190,12 @@ unsigned int getNumLineEndingStrokeDashes(SBMLDocument* document, unsigned int r
     return getNumStrokeDashes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumSpeciesReferenceLineEndingStrokeDashes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumReactionLineEndingStrokeDashes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumStrokeDashes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumStrokeDashes(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 unsigned int getLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dashIndex) {
@@ -1206,12 +1206,12 @@ unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int render
     return getStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex);
 }
 
-unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
-    return getSpeciesReferenceLineEndingStrokeDash(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, dashIndex);
+unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getReactionLineEndingStrokeDash(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, dashIndex);
 }
 
-unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
-    return getStrokeDash(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex);
+unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex) {
+    return getStrokeDash(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex);
 }
 
 int setLineEndingStrokeDash(SBMLDocument* document, const std::string& id, unsigned int dash) {
@@ -1230,11 +1230,11 @@ int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, co
     return setStrokeDash(getLineEndingRenderGroup(document, renderIndex, id), dashIndex, dash);
 }
 
-int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
     return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
 }
 
-int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
+int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash) {
     return setStrokeDash(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), dashIndex, dash);
 }
 
@@ -1246,12 +1246,12 @@ bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, 
     return isSetFillColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetReactionLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingFillColor(SBMLDocument* document, const std::string& id) {
@@ -1262,12 +1262,12 @@ const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int re
     return getFillColor(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEndingFillColor(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getFillColor(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillColor(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fillColor) {
@@ -1286,20 +1286,20 @@ int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int render
     return setFillColorAsGradient(getLineEndingRenderGroup(document, renderIndex, id), addGradient(document, getLineEnding(document, renderIndex, id), gradientType, stopsVector));
 }
 
-int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
 }
 
-int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
-    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
+int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
-int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
 }
 
-int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
-    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
+int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
 bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -1310,12 +1310,12 @@ bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, c
     return isSetFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+bool isSetReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetReactionLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return isSetFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+bool isSetReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetFillRule(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 const std::string getLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -1326,12 +1326,12 @@ const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int ren
     return getFillRule(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getSpeciesReferenceLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+const std::string getReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getReactionLineEndingFillRule(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getFillRule(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+const std::string getReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getFillRule(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 int setLineEndingFillRule(SBMLDocument* document, const std::string& id, const std::string& fillRule) {
@@ -1342,11 +1342,11 @@ int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, cons
     return setFillRule(getLineEndingRenderGroup(document, renderIndex, id), fillRule);
 }
 
-int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
     return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
 }
 
-int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
+int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule) {
     return setFillRule(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillRule);
 }
 
@@ -1358,12 +1358,12 @@ unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned in
     return getNumGeometricShapes(getLineEndingRenderGroup(document, renderIndex, id));
 }
 
-unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumSpeciesReferenceLineEndingGeometricShapes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumReactionLineEndingGeometricShapes(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
-unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
-    return getNumGeometricShapes(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
+unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getNumGeometricShapes(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)));
 }
 
 bool isLineEndingRectangle(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1374,12 +1374,12 @@ bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, con
     return isRectangle(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSpeciesReferenceLineEndingRectangle(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isReactionLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isReactionLineEndingRectangle(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRectangle(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRectangle(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingEllipse(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1390,12 +1390,12 @@ bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const
     return isEllipse(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isEllipse(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isEllipse(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingPolygon(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1406,12 +1406,12 @@ bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const
     return isPolygon(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isPolygon(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isPolygon(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingImage(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1422,12 +1422,12 @@ bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const s
     return isImage(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isImage(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isImage(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingRenderCurve(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1438,12 +1438,12 @@ bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, c
     return isRenderCurve(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isRenderCurve(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isRenderCurve(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingText(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1454,12 +1454,12 @@ bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const st
     return isText(getGeometricShape(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex));
 }
 
-bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isText(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isReactionLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isText(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isSetLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1470,12 +1470,12 @@ bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderI
     return isSetGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1486,12 +1486,12 @@ const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned
     return getGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1504,14 +1504,14 @@ const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsign
     return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
+const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getReactionLineEndingGeometricShapeX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector xVector = getSpeciesReferenceLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(xVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
+const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector xVector = getReactionLineEndingGeometricShapeX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(xVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(xVector);
 }
 
 int setLineEndingGeometricShapeX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& x) {
@@ -1522,11 +1522,11 @@ int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderInde
     return setGeometricShapeX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
     return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
+int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x) {
     return setGeometricShapeX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
@@ -1538,11 +1538,11 @@ int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int re
     return setGeometricShapeXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
+int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x) {
     return setGeometricShapeXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, x);
 }
 
@@ -1554,12 +1554,12 @@ bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderI
     return isSetGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1570,12 +1570,12 @@ const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned
     return getGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 
@@ -1589,14 +1589,14 @@ const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsign
     return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getReactionLineEndingGeometricShapeY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector yVector = getSpeciesReferenceLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(yVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
+const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector yVector = getReactionLineEndingGeometricShapeY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(yVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(yVector);
 }
 
 
@@ -1608,11 +1608,11 @@ int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderInde
     return setGeometricShapeY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
+int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y) {
     return setGeometricShapeY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
@@ -1624,11 +1624,11 @@ int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int re
     return setGeometricShapeYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
+int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y) {
     return setGeometricShapeYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, y);
 }
 
@@ -1640,12 +1640,12 @@ bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int ren
     return isSetGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeWidth(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1656,12 +1656,12 @@ const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsi
     return getGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeWidth(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1674,14 +1674,14 @@ const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, un
     return getAbsoluteValue(widthVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(widthVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
+const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getReactionLineEndingGeometricShapeWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector widthVector = getSpeciesReferenceLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(widthVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
+const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector widthVector = getReactionLineEndingGeometricShapeWidth(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(widthVector) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(widthVector);
 }
 
 int setLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& width) {
@@ -1692,11 +1692,11 @@ int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int render
     return setGeometricShapeWidth(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
     return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
+int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width) {
     return setGeometricShapeWidth(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
@@ -1708,11 +1708,11 @@ int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned in
     return setGeometricShapeWidthAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, width);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
+int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width) {
     return setGeometricShapeWidthAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, width);
 }
 
@@ -1724,12 +1724,12 @@ bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int re
     return isSetGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeHeight(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeHeight(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1740,12 +1740,12 @@ const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, uns
     return getGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHeight(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1758,14 +1758,14 @@ const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, u
     return getAbsoluteValue(heightVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(heightVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
+const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getReactionLineEndingGeometricShapeHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector heightVector = getSpeciesReferenceLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(heightVector) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
+const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector heightVector = getReactionLineEndingGeometricShapeHeight(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(heightVector) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(heightVector);
 }
 
 int setLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& height) {
@@ -1776,11 +1776,11 @@ int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int rende
     return setGeometricShapeHeight(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
     return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
+int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height) {
     return setGeometricShapeHeight(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
@@ -1792,11 +1792,11 @@ int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned i
     return setGeometricShapeHeightAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, height);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
+int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height) {
     return setGeometricShapeHeightAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, height);
 }
 
@@ -1808,12 +1808,12 @@ bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int ren
     return isSetGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRatio(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1824,12 +1824,12 @@ const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned i
     return getGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeRatio(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRatio(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 int setLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, double ratio) {
@@ -1840,11 +1840,11 @@ int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int render
     return setGeometricShapeRatio(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, ratio);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
     return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
+int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio) {
     return setGeometricShapeRatio(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, ratio);
 }
 
@@ -1856,12 +1856,12 @@ bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document,
     return isSetGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1872,12 +1872,12 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1890,14 +1890,14 @@ const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocum
     return getAbsoluteValue(cornerCurvatureRadiusXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusXVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusX) {
@@ -1908,11 +1908,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -1924,11 +1924,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* docu
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeCornerCurvatureRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -1940,12 +1940,12 @@ bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document,
     return isSetGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1956,12 +1956,12 @@ const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocumen
     return getGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -1974,14 +1974,14 @@ const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocum
     return getAbsoluteValue(cornerCurvatureRadiusYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(cornerCurvatureRadiusYVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& cornerCurvatureRadiusY) {
@@ -1992,11 +1992,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, un
     return setGeometricShapeCornerCurvatureRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2008,11 +2008,11 @@ int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* docu
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, cornerCurvatureRadiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeCornerCurvatureRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2024,12 +2024,12 @@ bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2040,12 +2040,12 @@ const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, un
     return getGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeCenterX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2058,14 +2058,14 @@ const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(xVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(xVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
+const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getReactionLineEndingGeometricShapeCenterX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerX = getSpeciesReferenceLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
+const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerX = getReactionLineEndingGeometricShapeCenterX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerX);
 }
 
 int setLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
@@ -2076,11 +2076,11 @@ int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
     return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
+int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX) {
     return setGeometricShapeCenterX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
@@ -2092,11 +2092,11 @@ int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeCenterXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
+int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX) {
     return setGeometricShapeCenterXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerX);
 }
 
@@ -2108,12 +2108,12 @@ bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeCenterY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2124,12 +2124,12 @@ const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, un
     return getGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeCenterY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeCenterY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2142,14 +2142,14 @@ const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(yVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(yVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
+const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getReactionLineEndingGeometricShapeCenterY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector centerY = getSpeciesReferenceLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(centerY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
+const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector centerY = getReactionLineEndingGeometricShapeCenterY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(centerY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(centerY);
 }
 
 int setLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
@@ -2160,11 +2160,11 @@ int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeCenterY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
     return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
+int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY) {
     return setGeometricShapeCenterY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
@@ -2176,11 +2176,11 @@ int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeCenterYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, centerY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
+int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY) {
     return setGeometricShapeCenterYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, centerY);
 }
 
@@ -2192,12 +2192,12 @@ bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2208,12 +2208,12 @@ const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, un
     return getGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeRadiusX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2226,14 +2226,14 @@ const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(rXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(rXVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getReactionLineEndingGeometricShapeRadiusX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusX = getSpeciesReferenceLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusX) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
+const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusX = getReactionLineEndingGeometricShapeRadiusX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusX) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusX);
 }
 
 int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
@@ -2244,11 +2244,11 @@ int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
+int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX) {
     return setGeometricShapeRadiusX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -2260,11 +2260,11 @@ int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeRadiusXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
+int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX) {
     return setGeometricShapeRadiusXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusX);
 }
 
@@ -2276,12 +2276,12 @@ bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int r
     return isSetGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2292,12 +2292,12 @@ const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, un
     return getGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeRadiusY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeRadiusY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2310,14 +2310,14 @@ const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, 
     return getAbsoluteValue(rYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(rYVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getReactionLineEndingGeometricShapeRadiusY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    RelAbsVector radiusY = getSpeciesReferenceLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
-    return getAbsoluteValue(radiusY) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
+const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    RelAbsVector radiusY = getReactionLineEndingGeometricShapeRadiusY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+    return getAbsoluteValue(radiusY) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(radiusY);
 }
 
 int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
@@ -2328,11 +2328,11 @@ int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int rend
     return setGeometricShapeRadiusY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
+int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY) {
     return setGeometricShapeRadiusY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2344,11 +2344,11 @@ int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned 
     return setGeometricShapeRadiusYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
+int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY) {
     return setGeometricShapeRadiusYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, radiusY);
 }
 
@@ -2360,12 +2360,12 @@ const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document
     return getGeometricShapeNumElements(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeNumElements(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeNumElements(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeNumElements(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeNumElements(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2376,12 +2376,12 @@ bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsign
     return isRenderCubicBezier(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isReactionLineEndingGeometricShapeElementCubicBezier(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return isRenderCubicBezier(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return isRenderCubicBezier(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2392,12 +2392,12 @@ const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, u
     return getGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeElementX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeElementX(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementX(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2410,14 +2410,14 @@ const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document,
     return getAbsoluteValue(elementXVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(elementXVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
+const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getReactionLineEndingGeometricShapeElementX(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector x = getSpeciesReferenceLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(x) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
+const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector x = getReactionLineEndingGeometricShapeElementX(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(x) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(x);
 }
 
 int setLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
@@ -2428,11 +2428,11 @@ int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementX(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
     return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
+int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x) {
     return setGeometricShapeElementX(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
@@ -2444,11 +2444,11 @@ int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned
     return setGeometricShapeElementXAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
+int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x) {
     return setGeometricShapeElementXAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, x);
 }
 
@@ -2460,12 +2460,12 @@ const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, u
     return getGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeElementY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeElementY(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeElementY(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2478,14 +2478,14 @@ const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document,
     return getAbsoluteValue(elementYVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(elementYVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
+const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getReactionLineEndingGeometricShapeElementY(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector y = getSpeciesReferenceLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
+const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector y = getReactionLineEndingGeometricShapeElementY(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(y);
 }
 
 int setLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
@@ -2496,11 +2496,11 @@ int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int ren
     return setGeometricShapeElementY(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
     return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
+int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y) {
     return setGeometricShapeElementY(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
@@ -2512,11 +2512,11 @@ int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned
     return setGeometricShapeElementYAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
+int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y) {
     return setGeometricShapeElementYAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, y);
 }
 
@@ -2528,12 +2528,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document
     return getGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeBasePoint1X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1X(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2546,14 +2546,14 @@ const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint1XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint1XVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
+const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getReactionLineEndingGeometricShapeBasePoint1X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1X = getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
+const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1X = getReactionLineEndingGeometricShapeBasePoint1X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1X);
 }
 
 int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
@@ -2564,11 +2564,11 @@ int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
     return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
+int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X) {
     return setGeometricShapeBasePoint1X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
@@ -2580,11 +2580,11 @@ int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint1XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
+int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X) {
     return setGeometricShapeBasePoint1XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1X);
 }
 
@@ -2596,12 +2596,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document
     return getGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeBasePoint1Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint1Y(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2614,14 +2614,14 @@ const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint1YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint1YVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
+const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getReactionLineEndingGeometricShapeBasePoint1Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint1Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint1Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
+const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint1Y = getReactionLineEndingGeometricShapeBasePoint1Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint1Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint1Y);
 }
 
 int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
@@ -2632,11 +2632,11 @@ int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint1Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
     return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
+int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y) {
     return setGeometricShapeBasePoint1Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
@@ -2648,11 +2648,11 @@ int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint1YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
+int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y) {
     return setGeometricShapeBasePoint1YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint1Y);
 }
 
@@ -2664,12 +2664,12 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document
     return getGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeBasePoint2X(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getGeometricShapeBasePoint2X(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
 const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex) {
@@ -2682,14 +2682,14 @@ const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint2XVector) + 0.01 * getLineEndingBoundingBoxWidth(document, renderIndex, id) * getRelativeValue(basePoint2XVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
+const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getReactionLineEndingGeometricShapeBasePoint2X(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2X = getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2X) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
+const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2X = getReactionLineEndingGeometricShapeBasePoint2X(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2X) + 0.01 * getReactionLineEndingBoundingBoxWidth(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2X);
 }
 
 int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
@@ -2700,11 +2700,11 @@ int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2X(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
     return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
+int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X) {
     return setGeometricShapeBasePoint2X(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
@@ -2716,11 +2716,11 @@ int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint2XAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
+int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X) {
     return setGeometricShapeBasePoint2XAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2X);
 }
 
@@ -2732,11 +2732,11 @@ const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document
     return getGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    return getReactionLineEndingGeometricShapeBasePoint2Y(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
 }
 
-const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
     return getGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex);
 }
 
@@ -2750,14 +2750,14 @@ const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* docume
     return getAbsoluteValue(basePoint2YVector) + 0.01 * getLineEndingBoundingBoxHeight(document, renderIndex, id) * getRelativeValue(basePoint2YVector);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
+const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getReactionLineEndingGeometricShapeBasePoint2Y(document, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
 }
 
-const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
-    RelAbsVector basePoint2Y = getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
-    return getAbsoluteValue(basePoint2Y) + 0.01 * getSpeciesReferenceLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
+const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex) {
+    RelAbsVector basePoint2Y = getReactionLineEndingGeometricShapeBasePoint2Y(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex, elementIndex);
+    return getAbsoluteValue(basePoint2Y) + 0.01 * getReactionLineEndingBoundingBoxHeight(document, reactionId, reactionGlyphIndex, speciesReferenceIndex) * getRelativeValue(basePoint2Y);
 }
 
 int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
@@ -2768,11 +2768,11 @@ int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int 
     return setGeometricShapeBasePoint2Y(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
     return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
+int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y) {
     return setGeometricShapeBasePoint2Y(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
@@ -2784,11 +2784,11 @@ int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsig
     return setGeometricShapeBasePoint2YAsDouble(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
+int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y) {
     return setGeometricShapeBasePoint2YAsDouble(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, elementIndex, basePoint2Y);
 }
 
@@ -2800,12 +2800,12 @@ bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int rend
     return isSetGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetReactionLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return isSetGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return isSetGeometricShapeHref(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex) {
@@ -2816,12 +2816,12 @@ const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsign
     return getGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex);
 }
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getSpeciesReferenceLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getReactionLineEndingGeometricShapeHref(document, 0, reactionId, reactionGlyphIndex, speciesReferenceIndex, geometricShapeIndex);
 }
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
-    return getGeometricShapeHref(getRenderGroup(getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex) {
+    return getGeometricShapeHref(getRenderGroup(getReactionLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex);
 }
 
 int setLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, const std::string& href) {
@@ -2832,11 +2832,11 @@ int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderI
     return setGeometricShapeHref(getLineEndingRenderGroup(document, renderIndex, id), geometricShapeIndex, href);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
 }
 
-int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
+int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href) {
     return setGeometricShapeHref(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), geometricShapeIndex, href);
 }
 

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -159,8 +159,7 @@ int setBackgroundColor(SBMLDocument* document, const std::string& backgroundColo
 }
 
 int setBackgroundColor(SBMLDocument* document, unsigned int renderIndex, const std::string& backgroundColor) {
-    addColor(getGlobalRenderInformation(document, renderIndex), backgroundColor);
-    return setBackgroundColor(getGlobalRenderInformation(document, renderIndex), backgroundColor);
+    return setBackgroundColor(getGlobalRenderInformation(document, renderIndex), addColor(getGlobalRenderInformation(document, renderIndex), backgroundColor));
 }
 
 const unsigned int getNumGlobalColorDefinitions(SBMLDocument* document, unsigned int renderIndex) {
@@ -276,15 +275,17 @@ GradientBase* getGradientDefinition(SBMLDocument* document, const std::string& s
 }
 
 GradientBase* getGradientDefinition(SBMLDocument* document, unsigned int renderIndex, const std::string& sid) {
-    if (getGradientDefinition(getGlobalRenderInformation(document, renderIndex), sid))
-        return getGradientDefinition(getGlobalRenderInformation(document, renderIndex), sid);
+    GradientBase* gradientDefinition = getGradientDefinition(getGlobalRenderInformation(document, renderIndex), sid);
+    if (gradientDefinition)
+        return gradientDefinition;
 
     return getGradientDefinition(getLocalRenderInformation(document, 0, renderIndex), sid);
 }
 
 GradientBase* getGradientDefinition(SBMLDocument* document, unsigned int renderIndex, unsigned int gradientIndex) {
-    if (getGradientDefinition(getGlobalRenderInformation(document, renderIndex), gradientIndex))
-        return getGradientDefinition(getGlobalRenderInformation(document, renderIndex), gradientIndex);
+    GradientBase* gradientDefinition = getGradientDefinition(getGlobalRenderInformation(document, renderIndex), gradientIndex);
+    if (gradientDefinition)
+        return gradientDefinition;
 
     return getGradientDefinition(getLocalRenderInformation(document, 0, renderIndex), gradientIndex);
 }
@@ -418,23 +419,19 @@ const std::string getStopColor(SBMLDocument* document, unsigned int renderIndex,
 }
 
 int setStopColor(SBMLDocument* document, const std::string& sid, const std::string& stopColor) {
-    addColor(getGlobalRenderInformation(document), stopColor);
-    return setStopColor(getGradientDefinition(document, sid), stopColor);
+    return setStopColor(getGradientDefinition(document, sid), addColor(getGlobalRenderInformation(document), stopColor));
 }
 
 int setStopColor(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, const std::string& stopColor) {
-    addColor(getGlobalRenderInformation(document, renderIndex), stopColor);
-    return setStopColor(getGradientDefinition(document, renderIndex, sid), stopColor);
+    return setStopColor(getGradientDefinition(document, renderIndex, sid), addColor(getGlobalRenderInformation(document, renderIndex), stopColor));
 }
 
 int setStopColor(SBMLDocument* document, const std::string& sid, unsigned int gradientStopIndex, const std::string& stopColor) {
-    addColor(getGlobalRenderInformation(document), stopColor);
-    return setStopColor(getGradientDefinition(document, sid), gradientStopIndex, stopColor);
+    return setStopColor(getGradientDefinition(document, sid), gradientStopIndex, addColor(getGlobalRenderInformation(document), stopColor));
 }
 
 int setStopColor(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, unsigned int gradientStopIndex, const std::string& stopColor) {
-    addColor(getGlobalRenderInformation(document, renderIndex), stopColor);
-    return setStopColor(getGradientDefinition(document, renderIndex, sid), gradientStopIndex, stopColor);
+    return setStopColor(getGradientDefinition(document, renderIndex, sid), gradientStopIndex, addColor(getGlobalRenderInformation(document, renderIndex), stopColor));
 }
 
 bool isSetLinearGradientX1(SBMLDocument* document, const std::string& sid) {
@@ -670,11 +667,11 @@ int setRadialGradientCy(SBMLDocument* document, unsigned int renderIndex, const 
 }
 
 int setRadialGradientCyAsDouble(SBMLDocument* document, const std::string& sid, const double& cy) {
-    return setRadialGradientCy(getGradientDefinition(document, sid), cy);
+    return setRadialGradientCyAsDouble(getGradientDefinition(document, sid), cy);
 }
 
 int setRadialGradientCyAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, const double& cy) {
-    return setRadialGradientCy(getGradientDefinition(document, renderIndex, sid), cy);
+    return setRadialGradientCyAsDouble(getGradientDefinition(document, renderIndex, sid), cy);
 }
 
 bool isSetRadialGradientFx(SBMLDocument* document, const std::string& sid) {
@@ -1098,23 +1095,19 @@ const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* documen
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, const std::string& id, const std::string& strokeColor) {
-    addColor(document, getLineEnding(document, id), strokeColor);
-    return setStrokeColor(getLineEndingRenderGroup(document, id), strokeColor);
+    return setStrokeColor(getLineEndingRenderGroup(document, id), addColor(document, getLineEnding(document, id), strokeColor));
 }
 
 int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& strokeColor) {
-    addColor(document, getLineEnding(document, renderIndex, id), strokeColor);
-    return setStrokeColor(getLineEndingRenderGroup(document, renderIndex, id), strokeColor);
+    return setStrokeColor(getLineEndingRenderGroup(document, renderIndex, id), addColor(document, getLineEnding(document, renderIndex, id), strokeColor));
 }
 
 int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor);
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeColor);
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
 int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor) {
-    addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor);
-    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), strokeColor);
+    return setStrokeColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), strokeColor));
 }
 
 bool isSetLineEndingStrokeWidth(SBMLDocument* document, const std::string& id) {
@@ -1278,23 +1271,35 @@ const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document,
 }
 
 int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fillColor) {
-    addColor(document, getLineEnding(document, id), fillColor);
-    return setFillColor(getLineEndingRenderGroup(document, id), fillColor);
+    return setFillColor(getLineEndingRenderGroup(document, id), addColor(document, getLineEnding(document, id), fillColor));
+}
+
+int setFillColorAsGradientAsGradient(SBMLDocument* document, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getLineEndingRenderGroup(document, id), addGradient(document, getLineEnding(document, id), gradientType, stopsVector));
 }
 
 int setLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillColor) {
-    addColor(document, getLineEnding(document, renderIndex, id), fillColor);
-    return setFillColor(getLineEndingRenderGroup(document, renderIndex, id), fillColor);
+    return setFillColor(getLineEndingRenderGroup(document, renderIndex, id), addColor(document, getLineEnding(document, renderIndex, id), fillColor));
+}
+
+int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getLineEndingRenderGroup(document, renderIndex, id), addGradient(document, getLineEnding(document, renderIndex, id), gradientType, stopsVector));
 }
 
 int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor);
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillColor);
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+}
+
+int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
 int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor) {
-    addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor);
-    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), fillColor);
+    return setFillColor(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addColor(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), fillColor));
+}
+
+int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    return setFillColorAsGradient(getRenderGroup(getSpeciesReferenceLocalLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex)), addGradient(document, getSpeciesReferenceLineEnding(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex), gradientType, stopsVector));
 }
 
 bool isSetLineEndingFillRule(SBMLDocument* document, const std::string& id) {
@@ -3081,8 +3086,7 @@ int setStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, con
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
-        addColor(document, style, stroke);
-        return setStrokeColor(style, stroke);
+        return setStrokeColor(style, addColor(document, style, stroke));
     }
 
     return -1;
@@ -3093,8 +3097,7 @@ int setStrokeColor(SBMLDocument* document, const std::string& attribute, const s
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        addColor(document, style, stroke);
-        return setStrokeColor(style, stroke);
+        return setStrokeColor(style, addColor(document, style, stroke));
     }
 
     return -1;
@@ -3473,8 +3476,7 @@ int setFontColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsig
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, graphicalObject);
-        addColor(document, style, fontColor);
-        return setFontColor(style, fontColor);
+        return setFontColor(style, addColor(document, style, fontColor));
     }
 
     return -1;
@@ -3490,8 +3492,7 @@ int setFontColor(SBMLDocument* document, const std::string& attribute, unsigned 
         Style* style = getLocalStyle(document, textGlyph);
         if (!style)
             style = createLocalStyle(document, textGlyph, getGraphicalObject(document, attribute));
-        addColor(document, style, fontColor);
-        return setFontColor(style, fontColor);
+        return setFontColor(style, addColor(document, style, fontColor));
     }
 
     return -1;
@@ -4466,8 +4467,7 @@ int setFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
-        addColor(document, style, fillColor);
-        return setFillColor(style, fillColor);
+        return setFillColor(style, addColor(document, style, fillColor));
     }
 
     return -1;
@@ -4478,8 +4478,29 @@ int setFillColor(SBMLDocument* document, const std::string& attribute, const std
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
-        addColor(document, style, fillColor);
-        return setFillColor(style, fillColor);
+        return setFillColor(style, addColor(document, style, fillColor));
+    }
+
+    return -1;
+}
+
+int setFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveFillColor(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
+    }
+
+    return -1;
+}
+
+int setFillColorAsGradient(SBMLDocument* document, const std::string& attribute, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveFillColor(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
     }
 
     return -1;
@@ -4497,6 +4518,14 @@ int setCompartmentFillColor(SBMLDocument* document, unsigned int layoutIndex, co
     return -1;
 }
 
+int setCompartmentFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (!setCompartmentFillColorAsGradient(getGlobalRenderInformation(document), addGradient(getGlobalRenderInformation(document, layoutIndex), gradientType, stopsVector)) && !setCompartmentFillColorAsGradient(
+            getLayout(document, layoutIndex), getLocalRenderInformation(document, layoutIndex), addGradient(getLocalRenderInformation(document, layoutIndex), gradientType, stopsVector)))
+        return 0;
+
+    return -1;
+}
+
 const std::string getSpeciesFillColor(SBMLDocument* document) {
     return getSpeciesFillColor(getGlobalRenderInformation(document));
 }
@@ -4509,6 +4538,14 @@ int setSpeciesFillColor(SBMLDocument* document, unsigned int layoutIndex, const 
     return -1;
 }
 
+int setSpeciesFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {;
+    if (!setSpeciesFillColorAsGradient(getGlobalRenderInformation(document), addGradient(getGlobalRenderInformation(document, layoutIndex), gradientType, stopsVector)) && !setSpeciesFillColorAsGradient(
+            getLayout(document, layoutIndex), getLocalRenderInformation(document, layoutIndex), addGradient(getLocalRenderInformation(document, layoutIndex), gradientType, stopsVector)))
+        return 0;
+
+    return -1;
+}
+
 const std::string getReactionFillColor(SBMLDocument* document) {
     return getReactionFillColor(getGlobalRenderInformation(document));
 }
@@ -4516,6 +4553,14 @@ const std::string getReactionFillColor(SBMLDocument* document) {
 int setReactionFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor) {
     if (!setReactionFillColor(getGlobalRenderInformation(document), fillColor) && !setReactionFillColor(
             getLayout(document, layoutIndex), getLocalRenderInformation(document, layoutIndex), fillColor))
+        return 0;
+
+    return -1;
+}
+
+int setReactionFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (!setReactionFillColorAsGradient(getGlobalRenderInformation(document), addGradient(getGlobalRenderInformation(document, layoutIndex), gradientType, stopsVector)) && !setReactionFillColorAsGradient(
+            getLayout(document, layoutIndex), getLocalRenderInformation(document, layoutIndex), addGradient(getLocalRenderInformation(document, layoutIndex), gradientType, stopsVector)))
         return 0;
 
     return -1;
@@ -4538,12 +4583,40 @@ int setLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, con
     return 0;
 }
 
+int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    for (unsigned int renderIndex = 0; renderIndex < getNumLocalRenderInformation(document, layoutIndex); renderIndex++) {
+        for (unsigned int lineEndingIndex = 0; lineEndingIndex < getNumLineEndings(getLocalRenderInformation(document, lineEndingIndex, renderIndex)); lineEndingIndex++) {
+            if (setLineEndingFillColorAsGradient(document, renderIndex, getLineEnding(getLocalRenderInformation(document, layoutIndex, renderIndex), lineEndingIndex)->getId(), gradientType, stopsVector))
+                return -1;
+        }
+    }
+    for (unsigned int renderIndex = 0; renderIndex < getNumGlobalRenderInformation(document); renderIndex++) {
+        for (unsigned int lineEndingIndex = 0; lineEndingIndex < getNumLineEndings(getGlobalRenderInformation(document, renderIndex)); lineEndingIndex++) {
+            if (setLineEndingFillColorAsGradient(document, renderIndex, getLineEnding(getGlobalRenderInformation(document, renderIndex), lineEndingIndex)->getId(), gradientType, stopsVector))
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
 int setFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor) {
     if (setCompartmentFillColor(document, layoutIndex, fillColor))
         return -1;
     if (setSpeciesFillColor(document, layoutIndex, fillColor))
         return -1;
     if (setReactionFillColor(document, layoutIndex, fillColor))
+        return -1;
+
+    return 0;
+}
+
+int setFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (setCompartmentFillColorAsGradient(document, layoutIndex, gradientType, stopsVector))
+        return -1;
+    if (setSpeciesFillColorAsGradient(document, layoutIndex, gradientType, stopsVector))
+        return -1;
+    if (setReactionFillColorAsGradient(document, layoutIndex, gradientType, stopsVector))
         return -1;
 
     return 0;
@@ -5227,12 +5300,34 @@ int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphica
     return -1;
 }
 
+int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
+    }
+
+    return -1;
+}
+
 int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor) {
     if (canHaveGeometricShape(graphicalObject)) {
         Style* style = getLocalStyle(document, graphicalObject);
         if (!style)
             style = createLocalStyle(document, graphicalObject);
         return setGeometricShapeFillColor(style, geometricShapeIndex, fillColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveGeometricShape(graphicalObject)) {
+        Style* style = getLocalStyle(document, graphicalObject);
+        if (!style)
+            style = createLocalStyle(document, graphicalObject);
+        return setGeometricShapeFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
     }
 
     return -1;
@@ -5249,12 +5344,34 @@ int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attrib
     return -1;
 }
 
+int setGeometricShapeFillColorAsGradient(SBMLDocument* document, const std::string& attribute, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
+    }
+
+    return -1;
+}
+
 int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor) {
     if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
         Style* style = getLocalStyle(document, attribute);
         if (!style)
             style = createLocalStyle(document, attribute);
         return setGeometricShapeFillColor(style, geometricShapeIndex, fillColor);
+    }
+
+    return -1;
+}
+
+int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector) {
+    if (canHaveGeometricShape(getGraphicalObject(document, attribute))) {
+        Style* style = getLocalStyle(document, attribute);
+        if (!style)
+            style = createLocalStyle(document, attribute);
+        return setGeometricShapeFillColorAsGradient(style, addGradient(document, style, gradientType, stopsVector));
     }
 
     return -1;

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -1250,7 +1250,7 @@ LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned
 
 LIBSBMLNETWORK_EXTERN LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
-LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN LineEnding* getReactionLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
@@ -1316,9 +1316,9 @@ LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* docume
 /// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 
 /// Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
@@ -1334,9 +1334,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* docum
 /// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1353,9 +1353,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
 
 /// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
@@ -1371,9 +1371,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* docum
 /// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 
 /// Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
@@ -1391,9 +1391,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
 /// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1408,9 +1408,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* d
 /// @return the value of the "width" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1427,9 +1427,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
 
 /// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1444,9 +1444,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* 
 /// @return the value of the "height" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1463,9 +1463,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document,
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
 /// Returns the value of the "group" element of the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1495,9 +1495,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1512,9 +1512,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* d
 /// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1531,9 +1531,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& stroke);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1550,9 +1550,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1567,9 +1567,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* docume
 /// @return the "stroke-width" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1586,9 +1586,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, double strokeWidth);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1605,9 +1605,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1664,9 +1664,9 @@ LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* documen
 /// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex = 0);
 
-LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 
 /// @brief Sets the first dash of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1698,9 +1698,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, const 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex, unsigned int dash);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
 /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1717,9 +1717,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, cons
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1734,9 +1734,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* doc
 /// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1757,13 +1757,13 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigne
 
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1780,9 +1780,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, const
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1797,9 +1797,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* docu
 /// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1815,9 +1815,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, const st
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillRule);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
 /// @brief Returns number of Transformation2D objects in the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1832,9 +1832,9 @@ LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument*
 /// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
 /// @param document a pointer to the SBMLDocument object.
@@ -1851,9 +1851,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, const s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
 /// @param document a pointer to the SBMLDocument object.
@@ -1870,9 +1870,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
 /// @param document a pointer to the SBMLDocument object.
@@ -1889,9 +1889,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
 /// @param document a pointer to the SBMLDocument object.
@@ -1908,9 +1908,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, const std::
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
 /// @param document a pointer to the SBMLDocument object.
@@ -1927,9 +1927,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, const
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
 /// @param document a pointer to the SBMLDocument object.
@@ -1946,9 +1946,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, const std::s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -1965,9 +1965,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document
 /// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1984,9 +1984,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocume
 /// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2003,9 +2003,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocu
 /// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2024,9 +2024,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2046,9 +2046,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
 /// @brief Checks if the Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2065,9 +2065,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document
 /// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2084,9 +2084,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocume
 /// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2103,9 +2103,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocu
 /// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2124,9 +2124,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2145,9 +2145,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
 /// @brief Checks if the width of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2164,9 +2164,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* docu
 /// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2183,9 +2183,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDo
 /// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2202,9 +2202,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBML
 /// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2223,9 +2223,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2244,9 +2244,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument*
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
 /// @brief Checks if the height of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2263,9 +2263,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* doc
 /// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2282,9 +2282,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLD
 /// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2301,9 +2301,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBM
 /// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2322,9 +2322,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* docume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2343,9 +2343,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
 /// @brief Checks if the ratio of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2362,9 +2362,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* docu
 /// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2381,9 +2381,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument
 /// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier.
@@ -2403,9 +2403,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, double ratio);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
 /// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2422,9 +2422,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(S
 /// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2441,9 +2441,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2460,9 +2460,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2481,9 +2481,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2502,9 +2502,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2521,9 +2521,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(S
 /// @return True if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2540,9 +2540,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return The Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2559,9 +2559,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2580,9 +2580,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2601,9 +2601,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Checks if the center X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2620,9 +2620,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* do
 /// @return True if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2639,9 +2639,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBML
 /// @return The center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2658,9 +2658,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SB
 /// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2679,9 +2679,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2700,9 +2700,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
 /// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2719,9 +2719,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* do
 /// @return True if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2738,9 +2738,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBML
 /// @return The center Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2757,9 +2757,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SB
 /// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2778,9 +2778,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2799,9 +2799,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
 /// @brief Checks if the radius X of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2818,9 +2818,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* do
 /// @return True if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2837,9 +2837,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBML
 /// @return The X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2856,9 +2856,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SB
 /// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2877,9 +2877,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2898,9 +2898,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y radius of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2917,9 +2917,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* do
 /// @return True if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2936,9 +2936,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBML
 /// @return The Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2955,9 +2955,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SB
 /// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2976,9 +2976,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2997,9 +2997,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Gets the number of elements in the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3016,9 +3016,9 @@ LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(
 /// @return The number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the geometric shape element for the LineEnding with the given identifier is a CubicBezier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3037,9 +3037,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocu
 /// @return True if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Gets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3058,9 +3058,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBM
 /// @return The X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3079,9 +3079,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(S
 /// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3102,9 +3102,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3125,9 +3125,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
 /// @brief Gets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3146,9 +3146,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBM
 /// @return The Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3167,9 +3167,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(S
 /// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3190,9 +3190,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3213,9 +3213,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
 /// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3234,9 +3234,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(
 /// @return The base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3255,9 +3255,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDoubl
 /// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3278,9 +3278,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3301,9 +3301,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
 /// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3322,9 +3322,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(
 /// @return The base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3343,9 +3343,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDoubl
 /// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3366,9 +3366,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3389,9 +3389,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
 /// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3410,9 +3410,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(
 /// @return The base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3431,9 +3431,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDoubl
 /// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3454,9 +3454,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3477,9 +3477,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
 /// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3498,9 +3498,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(
 /// @return The base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3519,9 +3519,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDoubl
 /// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3542,9 +3542,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3565,9 +3565,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
 /// @brief Checks if the Href attribute of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -3584,9 +3584,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* docum
 /// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3603,9 +3603,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocu
 /// @return The Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3624,9 +3624,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const std::string& href);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
-LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 /// @brief Searches among the styles of the first render information base in the SBML document and returns one that matches this GraphicalObject attributes
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -1745,6 +1745,8 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(S
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fill);
 
+LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
@@ -1753,9 +1755,15 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, const s
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fill);
 
+LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -4947,6 +4955,10 @@ LIBSBMLNETWORK_EXTERN int setFillColor(SBMLDocument* document, GraphicalObject* 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor);
 
+int setFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
+int setFillColorAsGradient(SBMLDocument* document, const std::string& attribute, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for the Compartment.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "fill" attribute of the RenderGroup of the Style for the Compartment, or @c "" if the object is @c NULL.
@@ -4958,6 +4970,8 @@ LIBSBMLNETWORK_EXTERN const std::string getCompartmentFillColor(SBMLDocument* do
 /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of these Style objects.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setCompartmentFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setCompartmentFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for the Species.
 /// @param document a pointer to the SBMLDocument object.
@@ -4971,6 +4985,8 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesFillColor(SBMLDocument* docume
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Returns the value of the "fill" attribute of the RenderGroup of the Style for the Reaction.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "fill" attribute of the RenderGroup of the Style for the Reaction, or @c "" if the object is @c NULL.
@@ -4983,6 +4999,8 @@ LIBSBMLNETWORK_EXTERN const std::string getReactionFillColor(SBMLDocument* docum
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setReactionFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Sets the value of the "fill" attribute of the RenderGroup of all LineEnding objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
@@ -4990,12 +5008,16 @@ LIBSBMLNETWORK_EXTERN int setReactionFillColor(SBMLDocument* document, unsigned 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor);
 
+LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Sets the value of the "fill" attribute of the RenderGroup of the Style for all GraphicalObject objects.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout object.
 /// @param fillColor a string value to use as the value of the "fill" attribute of the RenderGroup of these Style objects.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -5425,35 +5447,35 @@ LIBSBMLNETWORK_EXTERN bool isText(SBMLDocument* document, const std::string& att
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set,
-bool isSetGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke" attribute is not set or the object is @c NULL.
-bool isSetGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
-const std::string getGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
-const std::string getGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& strokeColor);
 
 /// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5461,14 +5483,14 @@ int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphi
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& strokeColor);
 
 /// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, const std::string& strokeColor);
 
 /// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5476,42 +5498,42 @@ int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attr
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& strokeColor);
 
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke-width" attribute is not set or the object is @c NULL.
-bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke-width" attribute is not set or the object is @c NULL.
-bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c 0.0 if the object is @c NULL.
-const double getGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c 0.0 if the object is @c NULL.
-const double getGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, const double& strokeWidth);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, const double& strokeWidth);
 
 /// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5519,14 +5541,14 @@ int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphi
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth);
 
 /// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, const double& strokeWidth);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, const double& strokeWidth);
 
 /// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5534,42 +5556,44 @@ int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attr
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth);
 
 /// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "fill" attribute is not set or the object is @c NULL.
-bool isSetGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "fill" attribute is not set or the object is @c NULL.
-bool isSetGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
-const std::string getGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
 
 /// @brief Returns the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @return the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
-const std::string getGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5577,14 +5601,18 @@ int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphica
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, const std::string& attribute, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
@@ -5592,7 +5620,9 @@ int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attrib
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
 /// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
 /// @return integer value indicating success/failure of the function.
-int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 // @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -112,19 +112,19 @@ LIBSBMLNETWORK_EXTERN int setDefaultLocalRenderInformationFeatures(SBMLDocument*
 
 /// @brief Create a GlobalRenderInformation object and add it to list of global renders of the SBML document, and
 /// Create a LocalRenderInformation object, add it to list of local renders of the Layout of the SBML document, and
-/// set all the necessary features for them.
+/// @brief Set all the necessary features for them.
 /// @param document a pointer to the SBMLDocument object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int createDefaultRenderInformation(SBMLDocument* document);
 
 /// @brief Create a GlobalRenderInformation object, add it to list of global renders of the SBML document, and
-/// set all the necessary features for it.
+/// @brief Set all the necessary features for it.
 /// @param document a pointer to the SBMLDocument object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int createDefaultGlobalRenderInformation(SBMLDocument* document);
 
 /// @brief Create a LocalRenderInformation object, add it to list of local renders of the Layout of the SBML document, and
-/// set all the necessary features for it.
+/// @brief Set all the necessary features for it.
 /// @param document a pointer to the SBMLDocument object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int createDefaultLocalRenderInformation(SBMLDocument* document);
@@ -1248,14 +1248,38 @@ LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned
 /// @return the @c LineEnding withf the given index, or NULL if LineEnding does not exist or the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned int renderIndex = 0, unsigned int lineEndingIndex = 0);
 
+/// @brief Clone the LineEnding with the given identifier from the RenderInformationBase object with the given index of the SBML document to create a new LineEnding that can be used locally by a SpeciesReferenceGlyph.
+/// @param document a pointer to the SBMLDocument object.
+/// @param globalLineEnding the LineEnding to be cloned.
+/// @param speciesReferenceGlyph the SpeciesReferenceGlyph that will use the new LineEnding.
+/// @return the new LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
+/// @brief Returns the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the LineEnding associated with the SpeciesReferenceGlyph with the given index, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the local LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document. Creates a new LineEnding from the global LineEnding if the local LineEnding does not exist.
+/// @param document a pointer to the SBMLDocument object.
+/// @reactionId a string representing the identifier of the Reaction object.
+/// @reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the LineEnding associated with the SpeciesReferenceGlyph with the given index, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the local LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document. Creates a new LineEnding from the global LineEnding if the local LineEnding does not exist.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @reactionId a string representing the identifier of the Reaction object.
+/// @reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the LineEnding associated with the SpeciesReferenceGlyph with the given index, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
-
 
 /// @brief Predicates returning @c true if the "enableRotationalMapping" attribute of the LineEnding with the given identifier
 /// of the first RenderInformationBase object of the SBML document is set.
@@ -1303,49 +1327,74 @@ LIBSBMLNETWORK_EXTERN int setEnableRotationalMapping(SBMLDocument* document, con
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setEnableRotationalMapping(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, bool enableRotationalMapping);
 
-/// Returns the bounding box for the LineEnding with the given identifier.
+/// @brief Returns the bounding box for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, const std::string& sid);
 
-/// Returns the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
+/// @brief Returns the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-
-/// Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid);
 
-/// Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
+/// @brief Returns the value of the "x" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "x" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-/// Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @param x a double to use as the value of the "x" attribute of the bounding box for this LineEnding object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, const std::string& sid, double x);
 
-/// Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1353,40 +1402,80 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double x);
 
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param x a double to use as the value of the "x" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param x a double to use as the value of the "x" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param x a double to use as the value of the "x" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x);
 
+/// @brief Sets the value of the "x" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param x a double to use as the value of the "x" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x);
 
-/// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid);
 
-/// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
+/// @brief Returns the value of the "y" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "y" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-
-/// Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @param y a double to use as the value of the "y" attribute of the bounding box for this LineEnding object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, const std::string& sid, double y);
 
-/// Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1394,21 +1483,49 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double y);
 
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param y a double to use as the value of the "y" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param y a double to use as the value of the "y" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param y a double to use as the value of the "y" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y);
 
+/// @brief Sets the value of the "y" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param y a double to use as the value of the "y" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y);
 
-/// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "width" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid);
 
-/// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1419,14 +1536,14 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth
 
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-/// Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @param width a double to use as the value of the "width" attribute of the bounding box for this LineEnding object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& sid, double width);
 
-/// Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1442,13 +1559,13 @@ LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* do
 
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width);
 
-/// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "height" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid);
 
-/// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1459,14 +1576,23 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeigh
 
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-/// Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& sid, double height);
 
-/// Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
+/// @brief Returns the value of the "width" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "width" attribute of the bounding box for this LineEnding, or \c 0.0 if the object is \c NULL
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1474,21 +1600,49 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document,
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double height);
 
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height);
 
+/// @brief Sets the value of the "height" attribute of the bounding box for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height);
 
-/// Returns the value of the "group" element of the LineEnding with the given identifier.
+/// @brief Returns the value of the "group" element of the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "group" element of this LineEnding as a RenderGroup, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN RenderGroup* getLineEndingRenderGroup(SBMLDocument* document, const std::string& sid);
 
-/// Returns the value of the "group" element of the LineEnding with the given identifier in the render information base with the givne index of the SBML document.
+/// @brief Returns the value of the "group" element of the LineEnding with the given identifier in the render information base with the givne index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1510,8 +1664,21 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Predicates returning \c true if the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "stroke" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "stroke" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Predicates returning \c true if the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "stroke" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "stroke" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1527,8 +1694,36 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* d
 /// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);/// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+/// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1546,12 +1741,40 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& stroke);
 
+/// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param strokeColor a string to use as the value of the "stroke" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
+/// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param strokeColor a string to use as the value of the "stroke" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
+/// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param strokeColor a string to use as the value of the "stroke" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor);
 
+/// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param strokeColor a string to use as the value of the "stroke" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor);
 
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1569,10 +1792,22 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Predicates returning \c true if the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "stroke-width" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "stroke-width" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Predicates returning \c true if the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "stroke-width" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "stroke-width" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
-
 /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1586,11 +1821,24 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* docume
 /// @return the "stroke-width" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object, or \c 0.0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object, or \c 0.0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-/// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
+// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @param strokeWidth a double to use as the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object.
@@ -1605,12 +1853,40 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, double strokeWidth);
 
+/// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param strokeWidth a double to use as the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
+/// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param strokeWidth a double to use as the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
+/// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param strokeWidth a double to use as the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth);
 
+/// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param strokeWidth a double to use as the value of the "stroke-width" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth);
 
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1628,8 +1904,21 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the number of dashes in the "stroke-dasharray" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the number of dashes in the "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the number of dashes in the "stroke-dasharray" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the number of dashes in the "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1687,10 +1976,25 @@ LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* documen
 /// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex = 0);
 
+/// @brief Returns the stroke dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to retrieve.
+/// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+/// @brief Returns the stroke dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to retrieve.
+/// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, \c 0 if the object is \c NULL.
 
+LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 /// @brief Sets the first dash of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1721,14 +2025,46 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, const 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex, unsigned int dash);
 
+/// @brief Sets the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to set.
+/// @param dash an unsigned int value to use as the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
+/// @brief Sets the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to set.
+/// @param dash an unsigned int value to use as the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
+/// @brief Sets the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to set.
+/// @param dash an unsigned int value to use as the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash);
+/// @brief Sets the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param dashIndex an unsigned int representing the index of the stroke dash to set.
+/// @param dash an unsigned int value to use as the dash at the given index of the 'stroke-dasharray' attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash);
 /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1744,10 +2080,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, cons
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Predicates returning \c true if the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "fill" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "fill" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+/// @brief Predicates returning \c true if the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "fill" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "fill" attribute is not set or the object is \c NULL.
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 /// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1761,8 +2110,21 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* doc
 /// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1772,6 +2134,12 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(S
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, const std::string& id, const std::string& fill);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier as a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param id a string representing the identifier of the LineEnding to retrieve.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier in the render information base with the given index of the SBML document.
@@ -1782,22 +2150,89 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* documen
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fill);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier as a gradient in the render information base with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param renderIndex the index number of the RenderInformationBase object.
+/// @param id a string representing the identifier of the LineEnding to retrieve.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param fillColor a string to use as the value of the "fill" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param fillColor a string to use as the value of the "fill" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param fillColor a string to use as the value of the "fill" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param fillColor a string to use as the value of the "fill" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param gradientType a string representing the type of gradient to use.
+/// @param stopsVector a vector of pairs where each pair consists of a string representing the color and a double representing the offset for the gradient stop.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1815,10 +2250,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, const
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Predicates returning \c true if the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "fill-rule" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "fill-rule" attribute is not set or the object is \c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+/// @brief Predicates returning \c true if the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return \c true if the "fill-rule" attribute of the RenderGroup for this LineEnding object is set, \c false if either the "fill-rule" attribute is not set or the object is \c NULL.
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1832,8 +2280,21 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* docu
 /// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
+/// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
@@ -1850,12 +2311,40 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, const st
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillRule);
 
+/// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param fillRule a string to use as the value of the "fill-rule" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
+/// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param fillRule a string to use as the value of the "fill-rule" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
+/// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param fillRule a string to use as the value of the "fill-rule" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule);
 
+/// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param fillRule a string to use as the value of the "fill-rule" attribute of the RenderGroup for this LineEnding object.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule);
 
 /// @brief Returns number of Transformation2D objects in the RenderGroup for the LineEnding with the given identifier
@@ -1871,10 +2360,23 @@ LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument*
 /// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+/// @brief Returns the number of Transformation2D objects in the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+/// @brief Returns the number of Transformation2D objects in the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1890,8 +2392,23 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, const s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type Rectangle.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type Rectangle.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
@@ -1909,8 +2426,23 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type Ellipse.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type Ellipse.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
@@ -1928,10 +2460,25 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type Polygon.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type Polygon.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, \c false otherwise.
 
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1947,8 +2494,23 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, const std::
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type Image.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type Image.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
@@ -1966,8 +2528,23 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, const
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type RenderCurve.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type RenderCurve.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
@@ -1985,8 +2562,23 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, const std::s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document is of type Text.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Predicates returning \c true if the Transformation2D at the given index of the RenderGroup for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is of type Text.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return \c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, \c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the X coordinate of the geometric shape for the LineEnding with the given identifier is set.
@@ -2004,8 +2596,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document
 /// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2023,8 +2630,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocume
 /// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2042,8 +2664,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocu
 /// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2063,12 +2700,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2088,12 +2757,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x);
 
 /// @brief Checks if the Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
@@ -2111,10 +2812,24 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document
 /// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
-
 /// @brief Gets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -2130,8 +2845,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocume
 /// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2149,10 +2879,24 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocu
 /// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
-
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2170,12 +2914,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2195,12 +2971,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y);
 
 /// @brief Checks if the width of the geometric shape for the LineEnding with the given identifier is set.
@@ -2218,8 +3026,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* docu
 /// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the width of the geometric shape for the LineEnding with the given identifier.
@@ -2237,8 +3060,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDo
 /// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the width of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2256,8 +3094,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBML
 /// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier.
@@ -2277,12 +3130,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2302,12 +3187,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument*
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width);
 
+/// @brief Sets the width of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param width the new width as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width);
 
 /// @brief Checks if the height of the geometric shape for the LineEnding with the given identifier is set.
@@ -2325,8 +3242,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* doc
 /// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the height of the geometric shape for the LineEnding with the given identifier.
@@ -2344,8 +3276,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLD
 /// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the height of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2363,10 +3310,24 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBM
 /// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
-
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2382,14 +3343,46 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* docume
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
 /// @param height the new height as a RelAbsVector.
 /// @return an integer indicating success (0) or failure (non-zero).
-LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& height);
+LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2409,12 +3402,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height);
 
+/// @brief Sets the height of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param height the new height as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height);
 
 /// @brief Checks if the ratio of the geometric shape for the LineEnding with the given identifier is set.
@@ -2432,8 +3457,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* docu
 /// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
+/// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier.
@@ -2451,8 +3491,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument
 /// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier.
@@ -2461,7 +3516,7 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRa
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
 /// @param ratio the new ratio as a double.
 /// @return an integer indicating success (0) or failure (non-zero).
-LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id,  unsigned int geometricShapeIndex, double ratio);
+LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex, double ratio);
 
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier and render index.
 /// @param document a pointer to the SBMLDocument object.
@@ -2470,14 +3525,46 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* documen
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
 /// @param ratio the new ratio as a double.
 /// @return an integer indicating success (0) or failure (non-zero).
-LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, double ratio);
+LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, double ratio);
 
+/// @brief Sets the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param ratio the new ratio as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
+/// @brief Sets the ratio of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param ratio the new ratio as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
+/// @brief Sets the ratio of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param ratio the new ratio as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio);
 
+/// @brief Sets the ratio of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param ratio the new ratio as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio);
 
 /// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
@@ -2495,8 +3582,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(S
 /// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
@@ -2514,8 +3616,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
@@ -2533,8 +3650,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
@@ -2554,12 +3686,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
@@ -2579,12 +3743,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
@@ -2602,8 +3798,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(S
 /// @return True if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
@@ -2621,27 +3832,61 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return The Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout with of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
+/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
-/// @param id a string representing the identifier of the LineEnding.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier and render index as a double.
+/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
 /// @param document a pointer to the SBMLDocument object.
-/// @param renderIndex the index number of the RenderInformationBase object.
-/// @param id a string representing the identifier of the LineEnding.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
@@ -2661,12 +3906,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
@@ -2686,12 +3963,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y curvature radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Checks if the center X coordinate of the geometric shape for the LineEnding with the given identifier is set.
@@ -2709,8 +4018,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* do
 /// @return True if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2728,8 +4052,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBML
 /// @return The center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2747,8 +4086,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SB
 /// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2768,12 +4122,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2793,12 +4179,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX);
 
+/// @brief Sets the center X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerX the new center X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX);
 
 /// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
@@ -2816,8 +4234,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* do
 /// @return True if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2837,6 +4270,14 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBML
 
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2854,8 +4295,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SB
 /// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -2875,12 +4331,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2900,12 +4388,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY);
 
+/// @brief Sets the center Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param centerY the new center Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY);
 
 /// @brief Checks if the radius X of the geometric shape for the LineEnding with the given identifier is set.
@@ -2923,8 +4443,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* do
 /// @return True if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the radius X of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the radius X of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X radius of the geometric shape for the LineEnding with the given identifier.
@@ -2942,8 +4477,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBML
 /// @return The X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X radius of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2961,10 +4511,24 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SB
 /// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
-
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding to modify.
@@ -2982,12 +4546,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3007,12 +4603,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
+/// @brief Sets the X radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusX the new X radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y radius of the geometric shape for the LineEnding with the given identifier is set.
@@ -3030,8 +4658,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* do
 /// @return True if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return true if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y radius of the geometric shape for the LineEnding with the given identifier.
@@ -3049,8 +4692,23 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBML
 /// @return The Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the first Layout of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3068,8 +4726,23 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SB
 /// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier.
@@ -3089,12 +4762,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3114,12 +4819,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
+/// @brief Sets the Y radius of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to modify.
+/// @param radiusY the new Y radius as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Gets the number of elements in the geometric shape for the LineEnding with the given identifier.
@@ -3137,8 +4874,23 @@ LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(
 /// @return The number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Returns the number of elements in the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Returns the number of elements in the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the geometric shape element for the LineEnding with the given identifier is a CubicBezier.
@@ -3158,8 +4910,25 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocu
 /// @return True if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Checks if the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is a CubicBezier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return true if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Checks if the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is a CubicBezier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return true if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Gets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
@@ -3179,8 +4948,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBM
 /// @return The X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
@@ -3200,8 +4986,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(S
 /// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
@@ -3223,12 +5026,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
@@ -3250,12 +5089,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
+/// @brief Sets the X coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param x the new X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
 /// @brief Gets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
@@ -3275,8 +5150,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBM
 /// @return The Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
@@ -3296,8 +5188,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(S
 /// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
@@ -3319,12 +5228,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
@@ -3346,12 +5291,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
+/// @brief Sets the Y coordinate of the geometric shape element for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param y the new Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
 /// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3371,8 +5352,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(
 /// @return The base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3392,8 +5390,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDoubl
 /// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3415,12 +5430,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3442,12 +5493,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
+/// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1X the new base point 1 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
 /// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3467,8 +5554,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(
 /// @return The base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3488,8 +5592,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDoubl
 /// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3511,12 +5632,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3538,12 +5695,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
+/// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint1Y the new base point 1 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
 /// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3563,8 +5756,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(
 /// @return The base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3584,8 +5794,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDoubl
 /// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3607,12 +5834,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3634,12 +5897,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
+/// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2X the new base point 2 X coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
 /// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3659,8 +5958,25 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(
 /// @return The base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3680,8 +5996,25 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDoubl
 /// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+/// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
+/// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
@@ -3703,12 +6036,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a RelAbsVector.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -3730,12 +6099,48 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
+/// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document as a double.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param elementIndex an unsigned int representing the index of the element.
+/// @param basePoint2Y the new base point 2 Y coordinate as a double.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
 /// @brief Checks if the Href attribute of the geometric shape for the LineEnding with the given identifier is set.
@@ -3753,8 +6158,23 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* docum
 /// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Checks if the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Checks if the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Href attribute of the geometric shape for the LineEnding with the given identifier.
@@ -3772,8 +6192,23 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocu
 /// @return The Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+/// @brief Gets the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
+/// @brief Gets the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @return the Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Href attribute of the geometric shape for the LineEnding with the given identifier.
@@ -3793,12 +6228,44 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const std::string& href);
 
+/// @brief Sets the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param href the new Href attribute as a string.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
+/// @brief Sets the Href attribute of the geometric shape for the LineEnding associated with the SpeciesReferenceGlyph with the given index of the reaction glyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param speciesReferenceIndex the index number of the SpeciesReference object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param href the new Href attribute as a string.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
+/// @brief Sets the Href attribute of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param href the new Href attribute as a string.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href);
 
+/// @brief Sets the Href attribute of the geometric shape for the LineEnding associated with the ReactionGlyph with the given index of the reaction with the given identifier in the Layout with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout object.
+/// @param reactionId a string representing the identifier of the Reaction object.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object.
+/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
+/// @param href the new Href attribute as a string.
+/// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 /// @brief Searches among the styles of the first render information base in the SBML document and returns one that matches this GraphicalObject attributes
@@ -3990,26 +6457,26 @@ LIBSBMLNETWORK_EXTERN Style* getStyleByType(SBMLDocument* document, const std::s
 /// @return a pointer to the found Style object.
 LIBSBMLNETWORK_EXTERN Style* getStyleByType(SBMLDocument* document, unsigned int renderIndex, const std::string& type);
 
-/// Returns the value of the "group" element of the Style for this GraphicalObject.
+/// @brief Returns the value of the "group" element of the Style for this GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return the value of the "group" element of the Style for this GraphicalObjet as a RenderGroup, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN RenderGroup* getRenderGroup(SBMLDocument* document, GraphicalObject* graphicalObject);
 
-/// Returns the value of the "group" element of the Style for this GraphicalObject in the render information base with the givne index of the SBML document.
+/// @brief Returns the value of the "group" element of the Style for this GraphicalObject in the render information base with the givne index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return the value of the "group" element of the Style for this GraphicalObjet as a RenderGroup, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN RenderGroup* getRenderGroup(SBMLDocument* document, unsigned int renderIndex, GraphicalObject* graphicalObject);
 
-/// Returns the value of the "group" element of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @brief Returns the value of the "group" element of the Style that matches this attribute (id, role, type) of a GraphicalObject.
 /// @param document a pointer to the SBMLDocument object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
 /// @return a pointer to the found Style object.
 LIBSBMLNETWORK_EXTERN RenderGroup* getRenderGroup(SBMLDocument* document, const std::string& attribute);
 
-/// Returns the value of the "group" element of the Style that matches this attribute (id, role, type) of a GraphicalObject in the render information base with the givne index of the SBML document.
+/// @brief Returns the value of the "group" element of the Style that matches this attribute (id, role, type) of a GraphicalObject in the render information base with the givne index of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param renderIndex the index number of the RenderInformationBase object.
 /// @param attribute the attribute (id, role, type) of a GraphicalObject.
@@ -5766,6 +8233,12 @@ LIBSBMLNETWORK_EXTERN const std::string getGeometricShapeFillColor(SBMLDocument*
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject in the form of a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param gradientType a string value that determines what type of gradient (linear or radial) to use.
+/// @param stopsVector a vector of pairs of strings and doubles that represent the color and offset of the gradient stops.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
@@ -5776,6 +8249,13 @@ LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* doc
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject in the form of a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param gradientType a string value that determines what type of gradient (linear or radial) to use.
+/// @param stopsVector a vector of pairs of strings and doubles that represent the color and offset of the gradient stops.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
@@ -5785,6 +8265,13 @@ LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* doc
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor);
 
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject in the form of a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param gradientType a string value that determines what type of gradient (linear or radial) to use.
+/// @param stopsVector a vector of pairs of strings and doubles that represent the color and offset of the gradient stops.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, const std::string& attribute, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
@@ -5795,6 +8282,13 @@ LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* doc
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor);
 
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject in the form of a gradient.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param gradientType a string value that determines what type of gradient (linear or radial) to use.
+/// @param stopsVector a vector of pairs of strings and doubles that represent the color and offset of the gradient stops.
+/// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setGeometricShapeFillColorAsGradient(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 // @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -1357,6 +1357,9 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double x);
 
 /// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1395,6 +1398,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double y);
+
 /// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1431,6 +1438,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocu
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double width);
+
 /// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1466,6 +1477,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document,
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double height);
 
 /// Returns the value of the "group" element of the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1535,6 +1550,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument*
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& strokeColor);
+
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1589,6 +1608,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, unsig
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const double strokeWidth);
 
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1702,6 +1725,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* 
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int dashIndex, unsigned int dash);
+
 /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1765,6 +1792,14 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* d
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1818,6 +1853,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, unsigned
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, const std::string& fillRule);
 
 /// @brief Returns number of Transformation2D objects in the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -2028,6 +2067,9 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocum
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2049,6 +2091,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* doc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& x);
 
 /// @brief Checks if the Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2128,6 +2174,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocum
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2148,6 +2198,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* doc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& y);
 
 /// @brief Checks if the width of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2227,6 +2281,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLD
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2247,6 +2305,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument*
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& width);
 
 /// @brief Checks if the height of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2326,6 +2388,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBML
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2346,6 +2412,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& height);
 
 /// @brief Checks if the ratio of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2385,7 +2455,6 @@ LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRa
 
 LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2406,6 +2475,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* documen
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& ratio);
 
 /// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2485,6 +2558,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurva
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2505,6 +2582,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDou
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2584,6 +2665,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurva
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2604,6 +2689,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDou
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Checks if the center X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2683,6 +2772,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBM
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2703,6 +2796,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocumen
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerX);
 
 /// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2782,6 +2879,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBM
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2802,6 +2903,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocumen
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& centerY);
 
 /// @brief Checks if the radius X of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2881,6 +2986,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBM
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2901,6 +3010,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocumen
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y radius of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2980,6 +3093,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBM
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3000,6 +3117,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocumen
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Gets the number of elements in the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3106,6 +3227,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SB
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3128,6 +3253,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocume
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
 /// @brief Gets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3194,6 +3323,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SB
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3216,6 +3349,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocume
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
 /// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3282,6 +3419,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3304,6 +3445,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDoc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
 /// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3370,6 +3515,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3392,6 +3541,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDoc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
 /// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3458,6 +3611,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3480,6 +3637,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDoc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
 /// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3546,6 +3707,10 @@ LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3568,6 +3733,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDoc
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
 /// @brief Checks if the Href attribute of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -3627,6 +3796,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href);
+
+LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 /// @brief Searches among the styles of the first render information base in the SBML document and returns one that matches this GraphicalObject attributes
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -1250,7 +1250,7 @@ LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned
 
 LIBSBMLNETWORK_EXTERN LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
-LIBSBMLNETWORK_EXTERN LineEnding* getReactionLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
@@ -1316,9 +1316,9 @@ LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* docume
 /// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN BoundingBox* getReactionLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 
 /// Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
@@ -1334,9 +1334,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* docum
 /// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1353,9 +1353,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
 
 
 /// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
@@ -1371,9 +1371,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* docum
 /// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 
 /// Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
@@ -1391,9 +1391,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
 
 /// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1408,9 +1408,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* d
 /// @return the value of the "width" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1427,9 +1427,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
 
 /// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1444,9 +1444,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* 
 /// @return the value of the "height" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1463,9 +1463,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document,
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
 /// Returns the value of the "group" element of the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1495,9 +1495,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1512,9 +1512,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* d
 /// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1531,9 +1531,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& stroke);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
 
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1550,9 +1550,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1567,9 +1567,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* docume
 /// @return the "stroke-width" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1586,9 +1586,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, double strokeWidth);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
 
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1605,9 +1605,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1664,9 +1664,9 @@ LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* documen
 /// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex = 0);
 
-LIBSBMLNETWORK_EXTERN unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
 
 /// @brief Sets the first dash of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1698,9 +1698,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, const 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex, unsigned int dash);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
 
 /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1717,9 +1717,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, cons
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1734,9 +1734,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* doc
 /// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1757,13 +1757,13 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigne
 
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColorAsGradient(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& gradientType, std::vector<std::pair<std::string, double>> stopsVector);
 
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1780,9 +1780,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, const
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1797,9 +1797,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* docu
 /// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1815,9 +1815,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, const st
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillRule);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
 
 /// @brief Returns number of Transformation2D objects in the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1832,9 +1832,9 @@ LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument*
 /// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
-LIBSBMLNETWORK_EXTERN unsigned int getNumReactionLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
 /// @param document a pointer to the SBMLDocument object.
@@ -1851,9 +1851,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, const s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
 /// @param document a pointer to the SBMLDocument object.
@@ -1870,9 +1870,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
 /// @param document a pointer to the SBMLDocument object.
@@ -1889,9 +1889,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
 /// @param document a pointer to the SBMLDocument object.
@@ -1908,9 +1908,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, const std::
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
 /// @param document a pointer to the SBMLDocument object.
@@ -1927,9 +1927,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, const
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
 /// @param document a pointer to the SBMLDocument object.
@@ -1946,9 +1946,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, const std::s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -1965,9 +1965,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document
 /// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1984,9 +1984,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocume
 /// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2003,9 +2003,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocu
 /// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2024,9 +2024,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
 
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
@@ -2046,9 +2046,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
 
 /// @brief Checks if the Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2065,9 +2065,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document
 /// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2084,9 +2084,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocume
 /// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2103,9 +2103,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocu
 /// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2124,9 +2124,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2145,9 +2145,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
 
 /// @brief Checks if the width of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2164,9 +2164,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* docu
 /// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2183,9 +2183,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDo
 /// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2202,9 +2202,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBML
 /// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2223,9 +2223,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2244,9 +2244,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument*
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
 
 /// @brief Checks if the height of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2263,9 +2263,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* doc
 /// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2282,9 +2282,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLD
 /// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2301,9 +2301,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBM
 /// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2322,9 +2322,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* docume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2343,9 +2343,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
 
 /// @brief Checks if the ratio of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2362,9 +2362,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* docu
 /// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2381,9 +2381,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument
 /// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier.
@@ -2403,9 +2403,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, double ratio);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
 
 /// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -2422,9 +2422,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(S
 /// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2441,9 +2441,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2460,9 +2460,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2481,9 +2481,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2502,9 +2502,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2521,9 +2521,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(S
 /// @return True if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2540,9 +2540,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return The Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2559,9 +2559,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2580,9 +2580,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2601,9 +2601,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Checks if the center X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2620,9 +2620,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* do
 /// @return True if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2639,9 +2639,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBML
 /// @return The center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2658,9 +2658,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SB
 /// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2679,9 +2679,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2700,9 +2700,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
 
 /// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2719,9 +2719,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* do
 /// @return True if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2738,9 +2738,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBML
 /// @return The center Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2757,9 +2757,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SB
 /// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2778,9 +2778,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2799,9 +2799,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
 
 /// @brief Checks if the radius X of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2818,9 +2818,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* do
 /// @return True if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2837,9 +2837,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBML
 /// @return The X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2856,9 +2856,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SB
 /// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2877,9 +2877,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2898,9 +2898,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
 
 /// @brief Checks if the Y radius of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -2917,9 +2917,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* do
 /// @return True if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2936,9 +2936,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBML
 /// @return The Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Returns the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2955,9 +2955,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SB
 /// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2976,9 +2976,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -2997,9 +2997,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
 
 /// @brief Gets the number of elements in the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3016,9 +3016,9 @@ LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(
 /// @return The number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const unsigned int getReactionLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the geometric shape element for the LineEnding with the given identifier is a CubicBezier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3037,9 +3037,9 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocu
 /// @return True if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN bool isReactionLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Gets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3058,9 +3058,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBM
 /// @return The X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3079,9 +3079,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(S
 /// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3102,9 +3102,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3125,9 +3125,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
 /// @brief Gets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3146,9 +3146,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBM
 /// @return The Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3167,9 +3167,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(S
 /// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3190,9 +3190,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3213,9 +3213,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
 /// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3234,9 +3234,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(
 /// @return The base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3255,9 +3255,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDoubl
 /// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3278,9 +3278,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3301,9 +3301,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
 /// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3322,9 +3322,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(
 /// @return The base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3343,9 +3343,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDoubl
 /// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3366,9 +3366,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3389,9 +3389,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
 
 /// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3410,9 +3410,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(
 /// @return The base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3431,9 +3431,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDoubl
 /// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3454,9 +3454,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3477,9 +3477,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
 /// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3498,9 +3498,9 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(
 /// @return The base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const RelAbsVector getReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3519,9 +3519,9 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDoubl
 /// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
-LIBSBMLNETWORK_EXTERN const double getReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3542,9 +3542,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
@@ -3565,9 +3565,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
 /// @brief Checks if the Href attribute of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
@@ -3584,9 +3584,9 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* docum
 /// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN bool isSetReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3603,9 +3603,9 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocu
 /// @return The Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-LIBSBMLNETWORK_EXTERN const std::string getReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3624,9 +3624,9 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const std::string& href);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
-LIBSBMLNETWORK_EXTERN int setReactionLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 /// @brief Searches among the styles of the first render information base in the SBML document and returns one that matches this GraphicalObject attributes
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -1248,6 +1248,15 @@ LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned
 /// @return the @c LineEnding withf the given index, or NULL if LineEnding does not exist or the object is @c NULL
 LIBSBMLNETWORK_EXTERN LineEnding* getLineEnding(SBMLDocument* document, unsigned int renderIndex = 0, unsigned int lineEndingIndex = 0);
 
+LIBSBMLNETWORK_EXTERN LineEnding* createLocalLineEnding(SBMLDocument* document, LineEnding* globalLineEnding, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
+LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN LineEnding* getSpeciesReferenceLocalLineEnding(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+
 /// @brief Predicates returning @c true if the "enableRotationalMapping" attribute of the LineEnding with the given identifier
 /// of the first RenderInformationBase object of the SBML document is set.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1307,6 +1316,11 @@ LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* docume
 /// @return the bounding box for the LineEnding object, or @c NULL if the object is @c NULL
 LIBSBMLNETWORK_EXTERN BoundingBox* getLineEndingBoundingBox(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
 
+LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN BoundingBox* getSpeciesReferenceLineEndingBoundingBox(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+
 /// Returns the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1319,6 +1333,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* docum
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "x" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "x" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1335,6 +1353,11 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxX(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double x);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double x);
+
+
 /// Returns the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1347,6 +1370,11 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* docum
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "y" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 
 /// Sets the value of the "y" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1363,6 +1391,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, cons
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxY(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double y);
+
 /// Returns the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1375,6 +1407,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* d
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "width" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "width" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1391,6 +1427,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double width);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double width);
+
 /// Returns the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
@@ -1403,6 +1443,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* 
 /// @param sid a string representing the identifier of the LineEnding to retrieve.
 /// @return the value of the "height" attribute of the bounding box for this LineEnding, or @c 0.0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN const double getLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// Sets the value of the "height" attribute of the bounding box for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1418,6 +1462,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document,
 /// @param height a double to use as the value of the "height" attribute of the bounding box for this LineEnding object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& sid, double height);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingBoundingBoxHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double height);
 
 /// Returns the value of the "group" element of the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1447,6 +1495,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1459,6 +1511,10 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* d
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @return the "stroke" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1475,6 +1531,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& stroke);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& strokeColor);
+
 /// @brief Predicates returning @c true if the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1490,6 +1550,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, co
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1502,6 +1566,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* docume
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @return the "stroke-width" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1518,6 +1586,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, const
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, double strokeWidth);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const double strokeWidth);
+
 /// @brief Predicates returning @c true if the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1532,6 +1604,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document
 /// @return @c true if the "stroke-dasharray" attribute of the RenderGroup for this LineEnding object is set, @c false if either the "stroke-dasharray"
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingStrokeDashArray(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingStrokeDashes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Returns the value of the "stroke-dasharray" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1588,6 +1664,10 @@ LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* documen
 /// @return the stroke dash at the given index of "stroke-dasharray" attribute of the RenderGroup for this LineEnding object, @c 0 if the object is @c NULL
 LIBSBMLNETWORK_EXTERN unsigned int getLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex = 0);
 
+LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+
+LIBSBMLNETWORK_EXTERN unsigned int getSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex);
+
 /// @brief Sets the first dash of the 'stroke-dasharray' attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1618,6 +1698,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, const 
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingStrokeDash(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int dashIndex, unsigned int dash);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingStrokeDash(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int dashIndex, unsigned int dash);
+
 /// @brief Predicates returning @c true if the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1633,6 +1717,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, cons
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 /// @brief Returns the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1645,6 +1733,10 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* doc
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @return the "fill" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1661,6 +1753,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, const s
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillColor(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fill);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillColor);
+
 /// @brief Predicates returning @c true if the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1676,6 +1772,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, const
 /// attribute is not set or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 /// @brief Returns the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1688,6 +1788,10 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* docu
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @return the "fill-rule" attribute of the RenderGroup for this LineEnding object, or @c NULL if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Sets the value of the "fill-rule" attribute of the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
@@ -1703,6 +1807,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, const st
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setLineEndingFillRule(SBMLDocument* document, unsigned int renderIndex, const std::string& id, const std::string& fillRule);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingFillRule(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, const std::string& fillRule);
+
 /// @brief Returns number of Transformation2D objects in the RenderGroup for the LineEnding with the given identifier
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1715,6 +1823,10 @@ LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument*
 /// @param id a string representing the identifier of the LineEnding to retrieve.
 /// @return the number of Transformation2D objects in the RenderGroup for this LineEnding object, or @c 0 if the object is @c NULL.
 LIBSBMLNETWORK_EXTERN unsigned int getNumLineEndingGeometricShapes(SBMLDocument* document, unsigned int renderIndex, const std::string& id);
+
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+LIBSBMLNETWORK_EXTERN unsigned int getNumSpeciesReferenceLineEndingGeometricShapes(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Rectangle.
 /// @param document a pointer to the SBMLDocument object.
@@ -1731,6 +1843,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, const s
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Rectangle, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRectangle(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRectangle(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Ellipse.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1745,6 +1861,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, const std
 /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Ellipse, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingEllipse(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingEllipse(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Polygon.
 /// @param document a pointer to the SBMLDocument object.
@@ -1761,6 +1881,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, const std
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Polygon, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingPolygon(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingPolygon(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Image.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1775,6 +1899,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, const std::
 /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Image, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingImage(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingImage(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type RenderCurve.
 /// @param document a pointer to the SBMLDocument object.
@@ -1791,6 +1919,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, const
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type RenderCurve, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingRenderCurve(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingRenderCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Predicates returning @c true if the Transformation2D at the given index of the RenderGroup of the LineEnding object of the RenderInformationBase object with the given index of the SBML document is of type Text.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1805,6 +1937,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, const std::s
 /// @param geometricShapeIndex an int representing the index of the Transformation2D to retrieve.
 /// @return @c true if the Transformation2D at the given index of the RenderGroup for this LineEnding object is of type Text, @c false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingText(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingText(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
@@ -1821,6 +1957,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document
 /// @return true if the X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Gets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1836,6 +1976,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocume
 /// @return the X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1850,6 +1994,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocu
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the X coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1868,6 +2016,11 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& x);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& x);
+
+
 /// @brief Sets the X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -1885,6 +2038,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& x);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& x);
+
 /// @brief Checks if the Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1899,6 +2056,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
 /// @return true if the Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1915,6 +2076,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocume
 /// @return the Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1929,6 +2094,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocu
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the Y coordinate as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1947,6 +2116,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, c
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& y);
+
 /// @brief Sets the Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -1964,6 +2137,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* doc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& y);
+
 /// @brief Checks if the width of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -1978,6 +2155,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* docu
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
 /// @return true if the width is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -1994,6 +2175,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDo
 /// @return the width as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -2008,6 +2193,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBML
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the width as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2026,6 +2215,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& width);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidth(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& width);
+
 /// @brief Sets the width of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2043,6 +2236,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument*
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& width);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeWidthAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& width);
+
 /// @brief Checks if the height of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -2057,6 +2254,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* doc
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape to check.
 /// @return true if the height is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2073,6 +2274,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLD
 /// @return the height as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to retrieve.
@@ -2087,6 +2292,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBM
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the height as a double, or \c 0 if the object is \c NULL.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2105,6 +2314,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* docume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& height);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeight(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& height);
+
 /// @brief Sets the height of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2121,6 +2334,11 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument
 /// @param height the new height as a double.
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& height);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHeightAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& height);
+
 /// @brief Checks if the ratio of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2135,6 +2353,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* docu
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return true if the ratio is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2151,20 +2373,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument
 /// @return the ratio as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
-/// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier as a double.
-/// @param document a pointer to the SBMLDocument object.
-/// @param id a string representing the identifier of the LineEnding.
-/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
-/// @return the ratio as a double.
-LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatioAsDouble(SBMLDocument* document, const std::string& id, unsigned int geometricShapeIndex = 0);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
-/// @brief Gets the ratio of the geometric shape for the LineEnding with the given identifier and render index as a double.
-/// @param document a pointer to the SBMLDocument object.
-/// @param renderIndex the index number of the RenderInformationBase object.
-/// @param id a string representing the identifier of the LineEnding.
-/// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
-/// @return the ratio as a double.
-LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRatioAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 
 /// @brief Sets the ratio of the geometric shape for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2183,6 +2395,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* documen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, double ratio);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRatio(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& ratio);
+
 /// @brief Checks if the X curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2197,6 +2413,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(S
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return true if the X curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2213,6 +2433,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return the X curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2227,6 +2451,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the X curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document a pointer to the SBMLDocument object.
@@ -2245,6 +2473,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
 /// @brief Sets the X curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2262,6 +2494,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
 /// @brief Checks if the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2276,6 +2512,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(S
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return True if the Y curvature radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2292,6 +2532,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvat
 /// @return The Y curvature radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2306,6 +2550,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRad
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the Y curvature radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2324,6 +2572,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBML
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& CornerCurvatureRadiusY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
 /// @brief Sets the Y curvature radius of the geometric shape corner for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2341,6 +2593,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDou
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& CornerCurvatureRadiusY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCornerCurvatureRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
 /// @brief Checks if the center X coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2355,6 +2611,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* do
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return True if the center X coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2371,6 +2631,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBML
 /// @return The center X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2385,6 +2649,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SB
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the center X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2403,6 +2671,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerX);
+
 /// @brief Sets the center X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2420,6 +2692,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerX);
+
 /// @brief Checks if the center Y coordinate of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2434,6 +2710,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* do
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return True if the center Y coordinate is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2450,6 +2730,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBML
 /// @return The center Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2464,6 +2748,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SB
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the center Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2482,6 +2770,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& centerY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& centerY);
+
 /// @brief Sets the center Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2499,6 +2791,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& centerY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeCenterYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& centerY);
+
 /// @brief Checks if the radius X of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2513,6 +2809,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* do
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return True if the radius X is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2529,6 +2829,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBML
 /// @return The X radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2543,6 +2847,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SB
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the X radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2561,6 +2869,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusX);
+
 /// @brief Sets the X radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2578,6 +2890,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusX);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusX);
+
 /// @brief Checks if the Y radius of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2592,6 +2908,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* do
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return True if the Y radius is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Gets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2608,6 +2928,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBML
 /// @return The Y radius as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Returns the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2622,6 +2946,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SB
 /// @param geometricShapeIndex an unsigned int representing the index of the geometric shape.
 /// @return the Y radius as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2640,6 +2968,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* docum
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const RelAbsVector& radiusY);
+
 /// @brief Sets the Y radius of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2657,6 +2989,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocumen
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const double& radiusY);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeRadiusYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const double& radiusY);
+
 /// @brief Gets the number of elements in the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2671,6 +3007,10 @@ LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return The number of elements as an unsigned int.
 LIBSBMLNETWORK_EXTERN const unsigned int getLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const unsigned int getSpeciesReferenceLineEndingGeometricShapeNumElements(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Checks if the geometric shape element for the LineEnding with the given identifier is a CubicBezier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2689,6 +3029,10 @@ LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocu
 /// @return True if the element is a CubicBezier, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceLineEndingGeometricShapeElementCubicBezier(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Gets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2706,6 +3050,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBM
 /// @return The X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2722,6 +3070,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(S
 /// @param elementIndex an unsigned int representing the index of the element.
 /// @return the X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2742,6 +3094,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& x);
+
 /// @brief Sets the X coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2761,6 +3117,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementXAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& x);
+
 /// @brief Gets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2778,6 +3138,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBM
 /// @return The Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2794,6 +3158,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(S
 /// @param elementIndex an unsigned int representing the index of the element.
 /// @return the Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2814,6 +3182,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* docu
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& y);
+
 /// @brief Sets the Y coordinate of the geometric shape element for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2833,6 +3205,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocume
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeElementYAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& y);
+
 /// @brief Gets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2850,6 +3226,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(
 /// @return The base point 1 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2866,6 +3246,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDoubl
 /// @param elementIndex an unsigned int representing the index of the element, defaulting to 0.
 /// @return the base point 1 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2886,6 +3270,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1X);
+
 /// @brief Sets the base point 1 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2905,6 +3293,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1X);
+
 /// @brief Gets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2922,6 +3314,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(
 /// @return The base point 1 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -2938,6 +3334,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDoubl
 /// @param elementIndex an unsigned int representing the index of the element, defaulting to 0.
 /// @return the base point 1 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -2958,6 +3358,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint1Y);
+
 /// @brief Sets the base point 1 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -2975,8 +3379,12 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDoc
 /// @param elementIndex an unsigned int representing the index of the element to modify.
 /// @param basePoint1Y the new base point 1 Y coordinate as a double.
 /// @return an integer indicating success (0) or failure (non-zero).
-
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint1YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint1Y);
+
 /// @brief Gets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -2994,6 +3402,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(
 /// @return The base point 2 X coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -3010,6 +3422,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDoubl
 /// @param elementIndex an unsigned int representing the index of the element, defaulting to 0.
 /// @return the base point 2 X coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3030,6 +3446,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2X);
+
 /// @brief Sets the base point 2 X coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3049,6 +3469,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2XAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2X);
+
 /// @brief Gets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -3066,6 +3490,10 @@ LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(
 /// @return The base point 2 Y coordinate as a RelAbsVector.
 LIBSBMLNETWORK_EXTERN const RelAbsVector getLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
 
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const RelAbsVector getSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
 /// @brief Returns the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding.
@@ -3082,6 +3510,10 @@ LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDoubl
 /// @param elementIndex an unsigned int representing the index of the element, defaulting to 0.
 /// @return the base point 2 Y coordinate as a double.
 LIBSBMLNETWORK_EXTERN const double getLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0, unsigned int elementIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
+
+LIBSBMLNETWORK_EXTERN const double getSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex);
 
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3102,6 +3534,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* d
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int renderIndex, const std::string& id,  unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const RelAbsVector& basePoint2Y);
+
 /// @brief Sets the base point 2 Y coordinate of the geometric shape for the LineEnding with the given identifier as a double.
 /// @param document a pointer to the SBMLDocument object.
 /// @param id a string representing the identifier of the LineEnding to modify.
@@ -3121,6 +3557,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDoc
 /// @return an integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
 
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeBasePoint2YAsDouble(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, unsigned int elementIndex, const double& basePoint2Y);
+
 /// @brief Checks if the Href attribute of the geometric shape for the LineEnding with the given identifier is set.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -3136,6 +3576,10 @@ LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* docum
 /// @return True if the Href attribute is set, false otherwise.
 LIBSBMLNETWORK_EXTERN bool isSetLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
 
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
 /// @brief Gets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
 /// @param id A string representing the identifier of the LineEnding.
@@ -3150,6 +3594,10 @@ LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocu
 /// @param geometricShapeIndex An unsigned int representing the index of the geometric shape.
 /// @return The Href attribute as a string.
 LIBSBMLNETWORK_EXTERN const std::string getLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex = 0);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
+
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex);
 
 /// @brief Sets the Href attribute of the geometric shape for the LineEnding with the given identifier.
 /// @param document A pointer to the SBMLDocument object.
@@ -3167,6 +3615,10 @@ LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document
 /// @param href The new Href attribute as a string.
 /// @return An integer indicating success (0) or failure (non-zero).
 LIBSBMLNETWORK_EXTERN int setLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int renderIndex, const std::string& id, unsigned int geometricShapeIndex, const std::string& href);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
+
+LIBSBMLNETWORK_EXTERN int setSpeciesReferenceLineEndingGeometricShapeHref(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int geometricShapeIndex, const std::string& href);
 
 /// @brief Searches among the styles of the first render information base in the SBML document and returns one that matches this GraphicalObject attributes
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -4968,7 +4968,181 @@ LIBSBMLNETWORK_EXTERN bool isText(SBMLDocument* document, GraphicalObject* graph
 /// it is not of type Text or is or the object is @c NULL.
 LIBSBMLNETWORK_EXTERN bool isText(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex = 0);
 
-/// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @brief Predicates returning @c true if the "storke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set,
+bool isSetGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke" attribute is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+const std::string getGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "stroke" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+const std::string getGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& strokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& strokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, const std::string& strokeColor);
+
+/// @brief Sets the value of the "stroke" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeColor a string value to use as the value of the "stroke" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& strokeColor);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke-width" attribute is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "stroke-width" attribute is not set or the object is @c NULL.
+bool isSetGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c 0.0 if the object is @c NULL.
+const double getGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "stroke-width" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c 0.0 if the object is @c NULL.
+const double getGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, const double& strokeWidth);
+
+/// @brief Sets the value of the "stroke-width" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param strokeWidth a double value to use as the value of the "stroke-width" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeStrokeWidth(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const double& strokeWidth);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "fill" attribute is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Predicates returning @c true if the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject is set.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return @c true if the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject is set, @c false if either the "fill" attribute is not set or the object is @c NULL.
+bool isSetGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+const std::string getGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex);
+
+/// @brief Returns the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @return the "fill" attribute of the Transformation2D object at the given index of the RenderGroup of the Style for this GraphicalObject, or @c "" if the object is @c NULL.
+const std::string getGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(SBMLDocument* document, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, const std::string& fillColor);
+
+/// @brief Sets the value of the "fill" attribute of the Transformation2D at the given index of the RenderGroup of the Style that matches this attribute (id, role, type) of a GraphicalObject.
+/// @param document a pointer to the SBMLDocument object.
+/// @param attribute the attribute (id, role, type) of a GraphicalObject.
+/// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.
+/// @param fillColor a string value to use as the value of the "fill" attribute of the Transformation2D object.
+/// @return integer value indicating success/failure of the function.
+int setGeometricShapeFillColor(SBMLDocument* document, const std::string& attribute, unsigned int geometricShapeIndex, const std::string& fillColor);
+
+// @brief Predicates returning @c true if the "x" attribute of the Transformation2D at the given index of the RenderGroup of the Style for this GraphicalObject is set.
 /// @param document a pointer to the SBMLDocument object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @param geometricShapeIndex an unsigned int representing the index of the Transformation2D to retrieve.

--- a/src/styles/libsbmlnetwork_styles.cpp
+++ b/src/styles/libsbmlnetwork_styles.cpp
@@ -812,10 +812,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         });
 
         const int scoreThreshold = 15;
-        if (styleScores.at(0).second <= scoreThreshold) {
-            std::cerr << "error: no predefined style found" << std::endl;
+        if (styleScores.at(0).second <= scoreThreshold)
             return "";
-        }
 
         return styleScores.at(0).first;
     }


### PR DESCRIPTION
- it is now possible to set the fill color as a gradient
- local line endings can now be created
-  'distribute' function now takes the order of the entered nodes into action
- functions which are related to setting/getting the stroke and fill color of the geometric shapes are added
- layout dimensions now consider that they start the x and y minimum value of the layout canvas is always zero
-  'maxNumConnectedEdges' which determines the criteria for creating alias nodes can now be passed to the 'autorender' function
- it is now possible to set the features of all line endings in a reaction using the reaction id.


- the issue with setting the color of reactions (and their species references) is now fixed
- the issue with setting more than two decimals for compartment extents is fixed for compartment dimension
- if no predefined style is found, then no error is thrown and just an empty string is returned
- A check is added to some layout_render layer functions to make sure the layout and local render information exists so that it does not lead to an access violation